### PR TITLE
Fix issues with library exporting in motion_predict

### DIFF
--- a/motion_predict/CMakeLists.txt
+++ b/motion_predict/CMakeLists.txt
@@ -27,10 +27,9 @@ find_package(Eigen3 REQUIRED)
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
   INCLUDE_DIRS include
-  #LIBRARIES motion_predict
+  LIBRARIES motion_predict
   CATKIN_DEPENDS cav_msgs roscpp
-  DEPENDS Eigen3
-#  DEPENDS system_lib
+  DEPENDS EIGEN3 # Eigen is a special case where is needs to be in caps here but not in find_package
 )
 
 ###########
@@ -50,7 +49,6 @@ add_library(motion_predict
   src/predict_ctrv.cpp
 )
 
-##add_library(motion_predict_lib src/motion_predict.cpp)
 add_dependencies(motion_predict ${catkin_EXPORTED_TARGETS})
 
 ## Specify libraries to link a library or executable target against
@@ -68,10 +66,8 @@ install(TARGETS motion_predict
 )
 
 ## Mark cpp header files for installation
-install(DIRECTORY include/
+install(DIRECTORY include/${PROJECT_NAME}/
         DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-        FILES_MATCHING PATTERN "*.h"
-        PATTERN ".svn" EXCLUDE
 )
 
 

--- a/motion_predict/include/motion_predict/motion_predict.h
+++ b/motion_predict/include/motion_predict/motion_predict.h
@@ -20,7 +20,7 @@
 #include <cav_msgs/ExternalObject.h>
 #include <cav_msgs/PredictedState.h>
 #include <cav_msgs/ExternalObjectList.h>
-#include "Eigen/Dense"
+#include <Eigen/Dense>
 #include <vector>
 
 namespace motion_predict{

--- a/motion_predict/include/motion_predict/predict_ctrv.h
+++ b/motion_predict/include/motion_predict/predict_ctrv.h
@@ -20,7 +20,7 @@
 #include <cav_msgs/ExternalObject.h>
 #include <cav_msgs/PredictedState.h>
 
-namespace predict
+namespace motion_predict
 {
 namespace ctrv
 {

--- a/motion_predict/src/motion_predict.cpp
+++ b/motion_predict/src/motion_predict.cpp
@@ -14,7 +14,7 @@
  * the License.
  */
 
-#include "motion_predict.h"
+#include "motion_predict/motion_predict.h"
 
 namespace motion_predict{
 

--- a/motion_predict/src/predict_ctrv.cpp
+++ b/motion_predict/src/predict_ctrv.cpp
@@ -14,8 +14,8 @@
  * the License.
  */
 
-#include "predict_ctrv.h"
-#include "motion_predict.h"
+#include "motion_predict/predict_ctrv.h"
+#include "motion_predict/motion_predict.h"
 #include <math.h>
 #include "Eigen/Dense"
 

--- a/motion_predict/test/test_motion_predict.cpp
+++ b/motion_predict/test/test_motion_predict.cpp
@@ -14,7 +14,7 @@
  * the License.
  */
 
-#include "motion_predict.h"
+#include "motion_predict/motion_predict.h"
 #include <gtest/gtest.h>
 
 namespace motion_predict{

--- a/motion_predict/test/test_predict_ctrv.cpp
+++ b/motion_predict/test/test_predict_ctrv.cpp
@@ -14,7 +14,7 @@
  * the License.
  */
 
-#include "predict_ctrv.h"
+#include "motion_predict/predict_ctrv.h"
 #include "../src/predict_ctrv.cpp"
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Fixes some issues with the motion_predict library being exported for use in other packages.  
<!--- Describe your changes in detail -->

## Related Issue
usdot-fhwa-stol/carma-platform#697
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Building with carma platform node using library
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.