### PR TITLE
Make system_alert global

### DIFF
--- a/carma_utils/src/carma_utils/CARMANodeHandle.cpp
+++ b/carma_utils/src/carma_utils/CARMANodeHandle.cpp
@@ -30,7 +30,7 @@ namespace ros {
    std::mutex CARMANodeHandle::spin_mutex_;
    bool CARMANodeHandle::shutting_down_ = false;
    bool CARMANodeHandle::allow_node_shutdown_ = true;
-   std::string CARMANodeHandle::system_alert_topic_ = "system_alert";
+   std::string CARMANodeHandle::system_alert_topic_ = "/system_alert";
    double CARMANodeHandle::default_spin_rate_ = 20.0;
 
    std::mutex CARMANodeHandle::static_pub_sub_mutex_;


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
By default the CARMANodeHandle system alert topic is not global this means remapping is necessary to point it at the correct topic. Given that this is generally not necessary the default should be the global topic. This should hopefully fix the linked issue.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/usdot-fhwa-stol/carma-platform/issues/963
## Motivation and Context
Stable sensor failure detection
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local testing in progress
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.