### PR TITLE
Fix/drivers use carma utils

### DIFF
--- a/cav_driver_utils/src/driver_application/driver_application.cpp
+++ b/cav_driver_utils/src/driver_application/driver_application.cpp
@@ -54,7 +54,7 @@ int DriverApplication::run()
     ros::ServiceServer driver_status_svs = pnh_->advertiseService("get_status", &DriverApplication::get_status_cb,this);
 
     driver_status_pub_ = nh_->advertise<cav_msgs::DriverStatus>("driver_discovery",1);
-    system_alert_sub_ = nh_->subscribe("system_alert",10,&DriverApplication::system_alert_cb, this);
+    system_alert_sub_ = nh_->subscribe("/system_alert",10,&DriverApplication::system_alert_cb, this);
     ros::Timer timer = pnh_->createTimer(ros::Duration(1), &DriverApplication::status_publish_timer,this);
     ROS_INFO("Driver services initialized");
 

--- a/cav_driver_utils/src/driver_wrapper/driver_wrapper.cpp
+++ b/cav_driver_utils/src/driver_wrapper/driver_wrapper.cpp
@@ -29,7 +29,7 @@ int DriverWrapper::run()
 
     //Initialize pubs and subs
     driver_status_pub_ = nh_->advertise<cav_msgs::DriverStatus>("driver_discovery", 1);
-    system_alert_sub_ = nh_->subscribe("system_alert", 10, &DriverWrapper::system_alert_cb, this);
+    system_alert_sub_ = nh_->subscribe("/system_alert", 10, &DriverWrapper::system_alert_cb, this);
     ros::Timer timer = private_nh_->createTimer(ros::Duration(1), &DriverWrapper::status_publish_timer, this);
 
     ROS_INFO_STREAM("Driver Initializing");


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Supports referenced PR by making driver_wrapper and driver_application use the correct system alert topic. Ideally those libraries would just use CARMANodeHanlde, but it seems non trivial to switch over. 
## Related Issue
usdot-fhwa-stol/carma-platform#963
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Better error handling
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Testing in blue lexus
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.