### PR TITLE
const jerk updates

### DIFF
--- a/trajectory_utils/include/trajectory_utils/conversions/conversions.h
+++ b/trajectory_utils/include/trajectory_utils/conversions/conversions.h
@@ -44,7 +44,11 @@ void speed_to_time(const std::vector<double>& downtrack, const std::vector<doubl
  * \param decel_jerk
  */
 void time_to_speed(const std::vector<double>& downtrack, const std::vector<double>& times, double initial_speed,
-                   std::vector<double>* speeds , std::vector<bool> isStopandWait, double decel_jerk);
+                   std::vector<double>* speeds);
+
+
+void time_to_speed_constjerk(const std::vector<double>& downtrack, const std::vector<double>& times, double initial_speed,
+                   std::vector<double>* speeds , double decel_jerk);
 
 /**
  * \brief Converts the trajectory points of a TrajectoryPlan message into equal sized vectors of downtrack distance and time

--- a/trajectory_utils/include/trajectory_utils/conversions/conversions.h
+++ b/trajectory_utils/include/trajectory_utils/conversions/conversions.h
@@ -40,13 +40,21 @@ void speed_to_time(const std::vector<double>& downtrack, const std::vector<doubl
  * \param initial_speed 
  * \param speeds Output parameter which points to the vector which will store the speeds at each point. 
  *              The first speed will always be initial_speed
- * \param isStopandWait A boolean vector for all points along downtrack, which defines whether they are part of the stop and wait maneuver or not
- * \param decel_jerk
  */
 void time_to_speed(const std::vector<double>& downtrack, const std::vector<double>& times, double initial_speed,
                    std::vector<double>* speeds);
 
-
+/**
+ * \brief Converts a list of times to a list of speeds for the corresponding downtrack points using constant jerk equations
+ * 
+ * \param downtracks The downtrack points where each speed and time will be
+ * \param times The time at each downtrack point. Must have the same length as the downtracks list
+ * \param initial_speed 
+ * \param speeds Output parameter which points to the vector which will store the speeds at each point. 
+ *              The first speed will always be initial_speed
+ * \param isStopandWait A boolean vector for all points along downtrack, which defines whether they are part of the stop and wait maneuver or not
+ * \param decel_jerk The decelerating constant jerk used in calculation
+ */
 void time_to_speed_constjerk(const std::vector<double>& downtrack, const std::vector<double>& times, double initial_speed,
                    std::vector<double>* speeds , double decel_jerk);
 

--- a/trajectory_utils/include/trajectory_utils/conversions/conversions.h
+++ b/trajectory_utils/include/trajectory_utils/conversions/conversions.h
@@ -1,6 +1,6 @@
 #pragma once
 /*
- * Copyright (C) 2021 LEIDOS.
+ * Copyright (C) 2020-2021 LEIDOS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -52,10 +52,9 @@ void time_to_speed(const std::vector<double>& downtrack, const std::vector<doubl
  * \param initial_speed 
  * \param speeds Output parameter which points to the vector which will store the speeds at each point. 
  *              The first speed will always be initial_speed
- * \param isStopandWait A boolean vector for all points along downtrack, which defines whether they are part of the stop and wait maneuver or not
  * \param decel_jerk The decelerating constant jerk used in calculation
  */
-void time_to_speed_constjerk(const std::vector<double>& downtrack, const std::vector<double>& times, double initial_speed,
+void time_to_speed_constjerk(const std::vector<double>& downtracks, const std::vector<double>& times, double initial_speed,
                    std::vector<double>* speeds , double decel_jerk);
 
 /**

--- a/trajectory_utils/include/trajectory_utils/conversions/conversions.h
+++ b/trajectory_utils/include/trajectory_utils/conversions/conversions.h
@@ -40,9 +40,11 @@ void speed_to_time(const std::vector<double>& downtrack, const std::vector<doubl
  * \param initial_speed 
  * \param speeds Output parameter which points to the vector which will store the speeds at each point. 
  *              The first speed will always be initial_speed
+ * \param isStopandWait A boolean vector for all points along downtrack, which defines whether they are part of the stop and wait maneuver or not
+ * \param decel_jerk
  */
 void time_to_speed(const std::vector<double>& downtrack, const std::vector<double>& times, double initial_speed,
-                   std::vector<double>* speeds);
+                   std::vector<double>* speeds , std::vector<bool> isStopandWait, double decel_jerk);
 
 /**
  * \brief Converts the trajectory points of a TrajectoryPlan message into equal sized vectors of downtrack distance and time

--- a/trajectory_utils/include/trajectory_utils/conversions/conversions.h
+++ b/trajectory_utils/include/trajectory_utils/conversions/conversions.h
@@ -1,6 +1,6 @@
 #pragma once
 /*
- * Copyright (C) 2018-2020 LEIDOS.
+ * Copyright (C) 2021 LEIDOS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/trajectory_utils/src/trajectory_utils/conversions/conversions.cpp
+++ b/trajectory_utils/src/trajectory_utils/conversions/conversions.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2020 LEIDOS.
+ * Copyright (C) 2018-2021 LEIDOS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -128,14 +128,12 @@ void time_to_speed(const std::vector<double>& downtrack, const std::vector<doubl
 
       if(delta_d == 0){
         cur_speed =0;
-        break;
+        continue;
       }
 
       if(decel_jerk > jerk_min){
         cur_speed = prev_speed - 0.5* decel_jerk*pow(dt,2);
-        if(cur_speed < 0){
-          cur_speed = 0;
-        }
+        cur_speed = std::max(0.0,cur_speed);
       }
       else{
         // stop and wait plugin doesn't create slow down traj for very low jerk requirement

--- a/trajectory_utils/src/trajectory_utils/conversions/conversions.cpp
+++ b/trajectory_utils/src/trajectory_utils/conversions/conversions.cpp
@@ -122,29 +122,9 @@ void time_to_speed(const std::vector<double>& downtrack, const std::vector<doubl
 
     double cur_speed;
     double jerk_min = 0.01; //Min stop and wait jerk
+
+    cur_speed = (2.0 * delta_d / dt) - prev_speed;
     
-    //if stop and wait, use constant jerk equations
-    if(isStopandWait[i]){
-
-
-      if(decel_jerk > jerk_min){
-        cur_speed = prev_speed - 0.5* decel_jerk*pow(dt,2);
-        cur_speed = std::max(0.0,cur_speed);
-      }
-      else{
-        // stop and wait plugin doesn't create slow down traj for very low jerk requirement
-        cur_speed = prev_speed;
-      }
-      
-      if(delta_d == 0){
-        cur_speed =0;
-      }
-      
-    }
-    //else use const acceleration equations
-    else{
-      cur_speed = (2.0 * delta_d / dt) - prev_speed;
-    }
     speeds->push_back(cur_speed);
 
     prev_position = cur_pos;
@@ -152,5 +132,56 @@ void time_to_speed(const std::vector<double>& downtrack, const std::vector<doubl
     prev_speed = cur_speed;
   }
 }
+
+void time_to_speed_constjerk(const std::vector<double>& downtrack, const std::vector<double>& times, double initial_speed,
+                   std::vector<double>* speeds, double decel_jerk)
+{
+  if (downtrack.size() != times.size())
+  {
+    throw std::invalid_argument("Input vector sizes do not match");
+  }
+
+  if (downtrack.size() == 0)
+  {
+    throw std::invalid_argument("Input vectors are empty");
+  }
+
+  speeds->reserve(downtrack.size());
+
+  double prev_position = downtrack[0];
+  double prev_speed = initial_speed;
+  double prev_time = times[0];
+  speeds->push_back(prev_speed);
+  for (int i = 1; i < downtrack.size(); i++)
+  {
+    double cur_pos = downtrack[i];
+    double cur_time = times[i];
+    double dt = cur_time - prev_time;
+    double delta_d = cur_pos - prev_position;
+
+    double cur_speed;
+    double jerk_min = 0.01; //Min stop and wait jerk
+    
+    if(decel_jerk > jerk_min){
+      cur_speed = prev_speed - 0.5* decel_jerk*pow(dt,2);
+      cur_speed = std::max(0.0,cur_speed);
+    }
+    else{
+      // stop and wait plugin doesn't create slow down traj for very low jerk requirement
+      cur_speed = prev_speed;
+    }
+    
+    if(delta_d == 0){
+      cur_speed =0;
+    }
+      
+    speeds->push_back(cur_speed);
+
+    prev_position = cur_pos;
+    prev_time = cur_time;
+    prev_speed = cur_speed;
+  }
+}
+
 };  // namespace conversions
 };  // namespace trajectory_utils

--- a/trajectory_utils/src/trajectory_utils/conversions/conversions.cpp
+++ b/trajectory_utils/src/trajectory_utils/conversions/conversions.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2021 LEIDOS.
+ * Copyright (C) 2021 LEIDOS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/trajectory_utils/src/trajectory_utils/conversions/conversions.cpp
+++ b/trajectory_utils/src/trajectory_utils/conversions/conversions.cpp
@@ -95,7 +95,7 @@ void speed_to_time(const std::vector<double>& downtrack, const std::vector<doubl
 }
 
 void time_to_speed(const std::vector<double>& downtrack, const std::vector<double>& times, double initial_speed,
-                   std::vector<double>* speeds,std::vector<bool> isStopandWait, double decel_jerk)
+                   std::vector<double>* speeds)
 {
   if (downtrack.size() != times.size())
   {
@@ -121,7 +121,6 @@ void time_to_speed(const std::vector<double>& downtrack, const std::vector<doubl
     double delta_d = cur_pos - prev_position;
 
     double cur_speed;
-    double jerk_min = 0.01; //Min stop and wait jerk
 
     cur_speed = (2.0 * delta_d / dt) - prev_speed;
     

--- a/trajectory_utils/src/trajectory_utils/conversions/conversions.cpp
+++ b/trajectory_utils/src/trajectory_utils/conversions/conversions.cpp
@@ -126,10 +126,6 @@ void time_to_speed(const std::vector<double>& downtrack, const std::vector<doubl
     //if stop and wait, use constant jerk equations
     if(isStopandWait[i]){
 
-      if(delta_d == 0){
-        cur_speed =0;
-        continue;
-      }
 
       if(decel_jerk > jerk_min){
         cur_speed = prev_speed - 0.5* decel_jerk*pow(dt,2);
@@ -138,6 +134,10 @@ void time_to_speed(const std::vector<double>& downtrack, const std::vector<doubl
       else{
         // stop and wait plugin doesn't create slow down traj for very low jerk requirement
         cur_speed = prev_speed;
+      }
+      
+      if(delta_d == 0){
+        cur_speed =0;
       }
       
     }

--- a/trajectory_utils/src/trajectory_utils/conversions/conversions.cpp
+++ b/trajectory_utils/src/trajectory_utils/conversions/conversions.cpp
@@ -170,8 +170,8 @@ void time_to_speed_constjerk(const std::vector<double>& downtrack, const std::ve
       cur_speed = prev_speed;
     }
     
-    if(delta_d == 0){
-      cur_speed =0;
+    if(delta_d == 0.0001){
+      cur_speed =0.0;
     }
       
     speeds->push_back(cur_speed);

--- a/trajectory_utils/src/trajectory_utils/conversions/conversions.cpp
+++ b/trajectory_utils/src/trajectory_utils/conversions/conversions.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 LEIDOS.
+ * Copyright (C) 2020-2021 LEIDOS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -170,7 +170,7 @@ void time_to_speed_constjerk(const std::vector<double>& downtrack, const std::ve
       cur_speed = prev_speed;
     }
     
-    if(delta_d == 0.0001){
+    if(std::abs(delta_d) <= 0.0001){
       cur_speed =0.0;
     }
       

--- a/trajectory_utils/test/trajectory_utils/test_conversions.cpp
+++ b/trajectory_utils/test/trajectory_utils/test_conversions.cpp
@@ -136,8 +136,6 @@ TEST(trajectory_utils_conversions_test, time_to_speed)
   std::vector<double> times = {1,2,3,4};
   std::vector<double> speeds;
 
-  std::vector<bool> isStopandWait;
-  isStopandWait.resize(downtracks.size(),0);
   double jerk = 0;
 
   time_to_speed(downtracks, times, 1.0, &speeds);
@@ -152,21 +150,18 @@ TEST(trajectory_utils_conversions_test, time_to_speed)
   downtracks = {};
   speeds = {};
   times = {};
-  isStopandWait.resize(downtracks.size(),0);
   ASSERT_THROW(time_to_speed(downtracks, times, 1.0, &speeds), std::invalid_argument);
 
   // Unequal input case
   downtracks = {1, 2};
   speeds = {1};
   times = {};
-  isStopandWait.resize(downtracks.size(),0);
   ASSERT_THROW(time_to_speed(downtracks, times, 1.0, &speeds), std::invalid_argument);
 
   // Complex case
   downtracks = {2, 4, 7};
   times = {0.0, 1.0, 2.5};
   speeds = {};
-  isStopandWait.resize(downtracks.size(),0);
   time_to_speed(downtracks, times, 1.0, &speeds);
   
   ASSERT_EQ(downtracks.size(), times.size());

--- a/trajectory_utils/test/trajectory_utils/test_conversions.cpp
+++ b/trajectory_utils/test/trajectory_utils/test_conversions.cpp
@@ -136,8 +136,6 @@ TEST(trajectory_utils_conversions_test, time_to_speed)
   std::vector<double> times = {1,2,3,4};
   std::vector<double> speeds;
 
-  double jerk = 0;
-
   time_to_speed(downtracks, times, 1.0, &speeds);
 
   ASSERT_EQ(downtracks.size(), speeds.size());

--- a/trajectory_utils/test/trajectory_utils/test_conversions.cpp
+++ b/trajectory_utils/test/trajectory_utils/test_conversions.cpp
@@ -140,7 +140,7 @@ TEST(trajectory_utils_conversions_test, time_to_speed)
   isStopandWait.resize(downtracks.size(),0);
   double jerk = 0;
 
-  time_to_speed(downtracks, times, 1.0, &speeds, isStopandWait, jerk);
+  time_to_speed(downtracks, times, 1.0, &speeds);
 
   ASSERT_EQ(downtracks.size(), speeds.size());
   for (size_t i = 0; i < speeds.size(); i++)
@@ -153,21 +153,21 @@ TEST(trajectory_utils_conversions_test, time_to_speed)
   speeds = {};
   times = {};
   isStopandWait.resize(downtracks.size(),0);
-  ASSERT_THROW(time_to_speed(downtracks, times, 1.0, &speeds, isStopandWait, jerk), std::invalid_argument);
+  ASSERT_THROW(time_to_speed(downtracks, times, 1.0, &speeds), std::invalid_argument);
 
   // Unequal input case
   downtracks = {1, 2};
   speeds = {1};
   times = {};
   isStopandWait.resize(downtracks.size(),0);
-  ASSERT_THROW(time_to_speed(downtracks, times, 1.0, &speeds, isStopandWait, jerk), std::invalid_argument);
+  ASSERT_THROW(time_to_speed(downtracks, times, 1.0, &speeds), std::invalid_argument);
 
   // Complex case
   downtracks = {2, 4, 7};
   times = {0.0, 1.0, 2.5};
   speeds = {};
   isStopandWait.resize(downtracks.size(),0);
-  time_to_speed(downtracks, times, 1.0, &speeds, isStopandWait, jerk);
+  time_to_speed(downtracks, times, 1.0, &speeds);
   
   ASSERT_EQ(downtracks.size(), times.size());
   ASSERT_NEAR(speeds[0], 1.0, 0.0000001);

--- a/trajectory_utils/test/trajectory_utils/test_conversions.cpp
+++ b/trajectory_utils/test/trajectory_utils/test_conversions.cpp
@@ -136,8 +136,11 @@ TEST(trajectory_utils_conversions_test, time_to_speed)
   std::vector<double> times = {1,2,3,4};
   std::vector<double> speeds;
 
+  std::vector<bool> isStopandWait;
+  isStopandWait.resize(downtracks.size(),0);
+  double jerk = 0;
 
-  time_to_speed(downtracks, times, 1.0, &speeds);
+  time_to_speed(downtracks, times, 1.0, &speeds, isStopandWait, jerk);
 
   ASSERT_EQ(downtracks.size(), speeds.size());
   for (size_t i = 0; i < speeds.size(); i++)
@@ -149,20 +152,22 @@ TEST(trajectory_utils_conversions_test, time_to_speed)
   downtracks = {};
   speeds = {};
   times = {};
-  ASSERT_THROW(time_to_speed(downtracks, times, 1.0, &speeds), std::invalid_argument);
+  isStopandWait.resize(downtracks.size(),0);
+  ASSERT_THROW(time_to_speed(downtracks, times, 1.0, &speeds, isStopandWait, jerk), std::invalid_argument);
 
   // Unequal input case
   downtracks = {1, 2};
   speeds = {1};
   times = {};
-  ASSERT_THROW(time_to_speed(downtracks, times, 1.0, &speeds), std::invalid_argument);
+  isStopandWait.resize(downtracks.size(),0);
+  ASSERT_THROW(time_to_speed(downtracks, times, 1.0, &speeds, isStopandWait, jerk), std::invalid_argument);
 
   // Complex case
   downtracks = {2, 4, 7};
   times = {0.0, 1.0, 2.5};
   speeds = {};
-  
-  time_to_speed(downtracks, times, 1.0, &speeds);
+  isStopandWait.resize(downtracks.size(),0);
+  time_to_speed(downtracks, times, 1.0, &speeds, isStopandWait, jerk);
   
   ASSERT_EQ(downtracks.size(), times.size());
   ASSERT_NEAR(speeds[0], 1.0, 0.0000001);


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
This PR adds const jerk for evaluating stop and wait type trajectory points.
Currently stop and wait type maneuver messages are handled the same way as constant acceleration maneuvers, when converting trajectory time data to speed.
## Description

<!--- Describe your changes in detail -->
The time to speed function is changed to accept additional parameters needed for jerk based evaluation.
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Integration Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.