### PR TITLE
Feature/default spin carma node handle

### DIFF
--- a/carma_utils/include/carma_utils/CARMANodeHandle.h
+++ b/carma_utils/include/carma_utils/CARMANodeHandle.h
@@ -59,7 +59,7 @@ namespace ros {
       static std::mutex static_pub_sub_mutex_;
       static bool shutting_down_; // Shutdown flag
       static std::string system_alert_topic_;
-      static boost::optional<double> spin_rate_; // Rate in seconds of spin loop. If this is not set then system will use event driven spin
+      static boost::optional<double> spin_rate_; // Rate in Hz of spin loop. If this is not set then system will use event driven spin
       // System alert pub/sub
       static volatile bool common_pub_sub_set_;
       static Subscriber system_alert_sub_;

--- a/carma_utils/include/carma_utils/CARMANodeHandle.h
+++ b/carma_utils/include/carma_utils/CARMANodeHandle.h
@@ -23,6 +23,7 @@
 #include <mutex>
 #include <memory>
 #include <cav_msgs/SystemAlert.h>
+#include <boost/optional.hpp>
 
 namespace ros {
   /**
@@ -58,8 +59,7 @@ namespace ros {
       static std::mutex static_pub_sub_mutex_;
       static bool shutting_down_; // Shutdown flag
       static std::string system_alert_topic_;
-      static double default_spin_rate_; // Rate in seconds of spin loop
-
+      static boost::optional<double> spin_rate_; // Rate in seconds of spin loop. If this is not set then system will use event driven spin
       // System alert pub/sub
       static volatile bool common_pub_sub_set_;
       static Subscriber system_alert_sub_;
@@ -193,14 +193,17 @@ namespace ros {
        * This callback will be triggered after each call to spinOnce()
        * If the callback function returns false the node will attempt to shutdown 
        * 
+       * @throw std::invalid_argument if the spin rate has not been set with setSpinRate(). This exception is caught internally but will cause the node to shutdown.
+       * 
        * @param cb Callback function
        */ 
       static void setSpinCallback(SpinCB cb);
       /**
        * @brief Exception safe replacement for ros::spin(). 
        * 
-       * Loops continuously at the rate set by setSpinRate();
-       * On each loop ros::spinOnce() is called then the spinCallback is triggered
+       * Equivalent to ros::spin() if setSpinRate() has not been called. 
+       * If it has been called then, this loops continuously at the rate set by setSpinRate();
+       * On rate controlled loop ros::spinOnce() is called then the spinCallback is triggered
        * This loop will exit and attempt to shutdown the node if the spin callback returns false
        * 
        */ 
@@ -218,6 +221,7 @@ namespace ros {
        * @brief Sets the spin rate of the spin() function
        * 
        * @param hz The rate in Hz at which the spin() function will call ros::spinOnce();
+       *           If set to 0.0 or a negative value it is equivalent to unsetting the rate so spin() will behave like ros::spin().
        * 
        */ 
       static void setSpinRate(double hz);

--- a/carma_utils/src/carma_utils/CARMANodeHandle.cpp
+++ b/carma_utils/src/carma_utils/CARMANodeHandle.cpp
@@ -20,6 +20,7 @@
 
 #include <sstream>
 #include "carma_utils/CARMANodeHandle.h"
+#include <ros/callback_queue.h>
 
 namespace ros {
   // Initialize default static values
@@ -31,7 +32,7 @@ namespace ros {
    bool CARMANodeHandle::shutting_down_ = false;
    bool CARMANodeHandle::allow_node_shutdown_ = true;
    std::string CARMANodeHandle::system_alert_topic_ = "/system_alert";
-   double CARMANodeHandle::default_spin_rate_ = 20.0;
+   boost::optional<double> CARMANodeHandle::spin_rate_;
 
    std::mutex CARMANodeHandle::static_pub_sub_mutex_;
    volatile bool CARMANodeHandle::common_pub_sub_set_ = false;
@@ -127,6 +128,12 @@ namespace ros {
 
   void CARMANodeHandle::setSpinCallback(SpinCB cb) {
     std::lock_guard<std::mutex> lock(spin_mutex_);
+    if (!spin_rate_) {
+      handleException(std::invalid_argument("Tried to set a spin callback however the spin_rate is not set. "));
+      return;
+      //throw std::invalid_argument("Tried to set a spin callback however the spin_rate is not set. "); TODO remove
+    }
+    ROS_WARN_STREAM("SPIN RATE " << spin_rate_.get());
     validateCallback(cb);
     spin_cb_ = cb;
   }
@@ -151,33 +158,55 @@ namespace ros {
 
   void CARMANodeHandle::setSpinRate(double hz) {
     std::lock_guard<std::mutex> lock(spin_mutex_);
-    default_spin_rate_ = hz;
+    if (hz <= 0.0) {
+      ROS_DEBUG("Unsetting spin rate as provided with 0 or negative frequency.");
+      spin_rate_ = boost::none;
+      return;
+    }
+    spin_rate_ = hz;
   }
 
   void CARMANodeHandle::spin() {
     ROS_INFO("Entered Spin: Waiting for any other calls to spin to complete");
     std::lock_guard<std::mutex> lock(spin_mutex_);
     ROS_INFO("Obtained lock. Starting spin");
-    // Continuosly process callbacks for default_nh_ using the GlobalCallbackQueue
-    ros::Rate r(default_spin_rate_);
-    while (ros::ok() && !shutting_down_)
-    {
-      ros::spinOnce();
-      try {
-        if (validFunctionPtr(spin_cb_) && !spin_cb_()) {
-          cav_msgs::SystemAlert alert_msg;
-          alert_msg.type = cav_msgs::SystemAlert::WARNING;
-          alert_msg.description = "Node: " + ros::this_node::getName() + " cleanly shutting down using CARMANodeHandle after spin callback returned false";
-          ROS_WARN_STREAM(alert_msg.description); // Log notice
 
-          system_alert_pub_.publish(alert_msg); // Notify the rest of the system
-          shutdown();
+    if (spin_rate_) {
+      ROS_INFO_STREAM("Using rate controlled spin at frequency: " << spin_rate_.get());
+      // Continuosly process callbacks for default_nh_ using the GlobalCallbackQueue
+      ros::Rate r(*spin_rate_);
+      while (ros::ok() && !shutting_down_)
+      {
+        ros::spinOnce();
+        try {
+          if (validFunctionPtr(spin_cb_) && !spin_cb_()) {
+            cav_msgs::SystemAlert alert_msg;
+            alert_msg.type = cav_msgs::SystemAlert::WARNING;
+            alert_msg.description = "Node: " + ros::this_node::getName() + " cleanly shutting down using CARMANodeHandle after spin callback returned false";
+            ROS_WARN_STREAM(alert_msg.description); // Log notice
+
+            system_alert_pub_.publish(alert_msg); // Notify the rest of the system
+            shutdown();
+          }
+        }
+        catch(const std::exception& e) {
+          handleException(e);
+        }
+        r.sleep();
+      }
+    } else {
+
+      ROS_INFO("Using event driven spin");
+      while (ros::ok() && !shutting_down_) // Default spin implementation with added exception handling based off implementation shown here http://wiki.ros.org/roscpp/Overview/Callbacks%20and%20Spinning and https://github.com/ros/ros_comm/blob/25af588f9971c3dee7f5a79f8ce143ad0c4644df/clients/roscpp/src/libros/spinner.cpp#L156
+      {
+        try {
+          ros::getGlobalCallbackQueue()->callAvailable(ros::WallDuration(0.1));
+        }
+        catch(const std::exception& e) {
+          handleException(e);
         }
       }
-      catch(const std::exception& e) {
-        handleException(e);
-      }
-      r.sleep();
+
     }
     
     { // Empty scope for applying lock_guard for shutdown

--- a/carma_utils/src/carma_utils/CARMANodeHandle.cpp
+++ b/carma_utils/src/carma_utils/CARMANodeHandle.cpp
@@ -132,7 +132,6 @@ namespace ros {
       handleException(std::invalid_argument("Tried to set a spin callback however the spin_rate is not set. "));
       return;
     }
-    ROS_WARN_STREAM("SPIN RATE " << spin_rate_.get());
     validateCallback(cb);
     spin_cb_ = cb;
   }

--- a/carma_utils/src/carma_utils/CARMANodeHandle.cpp
+++ b/carma_utils/src/carma_utils/CARMANodeHandle.cpp
@@ -131,7 +131,6 @@ namespace ros {
     if (!spin_rate_) {
       handleException(std::invalid_argument("Tried to set a spin callback however the spin_rate is not set. "));
       return;
-      //throw std::invalid_argument("Tried to set a spin callback however the spin_rate is not set. "); TODO remove
     }
     ROS_WARN_STREAM("SPIN RATE " << spin_rate_.get());
     validateCallback(cb);

--- a/carma_utils/test/carma_utils/CARMANodeHandleTest.cpp
+++ b/carma_utils/test/carma_utils/CARMANodeHandleTest.cpp
@@ -215,6 +215,7 @@ TEST(CARMANodeHandleTests, testCARMANodeHandleConstructor)
 
   cnh.setSystemAlertCallback([](const cav_msgs::SystemAlertConstPtr& msg) -> void {});
 
+  cnh.setSpinRate(20.0);
   cnh.setSpinCallback([]() -> bool {return true;});
 
   CARMANodeHandle cnh2(cnh);
@@ -575,7 +576,7 @@ TEST (CARMANodeHandleTests, testCARMANodeHandleSpin) {
   cnh.setShutdownCallback([]() -> void {});
 
   cnh.setSystemAlertCallback([](const cav_msgs::SystemAlertConstPtr& msg) -> void {});
-
+  cnh.setSpinRate(20.0);
   cnh.setSpinCallback([]() -> bool {
     static int callCount = 0;
     CallRecorder::markCalled("testCARMANodeHandleSpin","::spinLambda1");
@@ -592,6 +593,25 @@ TEST (CARMANodeHandleTests, testCARMANodeHandleSpin) {
 
   cnh.spin(); // Blocks until spin callback returns false
   ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleSpin", "::spinLambda1"), 4);
+}
+
+TEST(CARMANodeHandleTests, testSetSpinException)
+{
+  CARMANodeHandle cnh;
+  cnh.setSpinRate(0.0);
+
+  bool gotException = false;
+  bool shutdown_called = false;
+  cnh.setExceptionCallback([&gotException](const std::exception& exp) -> void { gotException = true; });
+
+  cnh.setShutdownCallback([&shutdown_called]() -> void { shutdown_called = true; });
+
+  cnh.setSystemAlertCallback([](const cav_msgs::SystemAlertConstPtr& msg) -> void {});
+
+  cnh.setSpinCallback([]() -> bool {return true;});
+
+  ASSERT_TRUE(gotException);
+  ASSERT_TRUE(shutdown_called);
 }
 
 int main(int argc, char **argv)

--- a/carma_utils/test/carma_utils/CARMANodeHandleTest.cpp
+++ b/carma_utils/test/carma_utils/CARMANodeHandleTest.cpp
@@ -215,9 +215,6 @@ TEST(CARMANodeHandleTests, testCARMANodeHandleConstructor)
 
   cnh.setSystemAlertCallback([](const cav_msgs::SystemAlertConstPtr& msg) -> void {});
 
-  cnh.setSpinRate(20.0);
-  cnh.setSpinCallback([]() -> bool {return true;});
-
   CARMANodeHandle cnh2(cnh);
 
   CARMANodeHandle cnh3(cnh, "h");

--- a/driver_shutdown/src/driver_shutdown.cpp
+++ b/driver_shutdown/src/driver_shutdown.cpp
@@ -31,7 +31,6 @@ namespace driver_shutdown
     void DriverShutdown::run()
     {
     	initialize();
-        ros::CARMANodeHandle::setSpinRate(10.0);
         ros::CARMANodeHandle::spin();
 
     }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR changes the default spin functionality of CARMANodeHandle to reflect ros::spin() unless the spin rate has been explicitly set. If it has been set then it operates as before. 
This is a step on the path to resolving https://github.com/usdot-fhwa-stol/carma-platform/issues/1211

Also removes the setSpinRate() call from driver_shutdown to make it an event driven node. 
<!--- Describe your changes in detail -->

This PR should not be merged until refactor PRs for carma-platform and carma-messenger have also been implemented. 
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Reduced latency in ros system
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Unit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.