### PR TITLE
Working proj_tools implementation

### DIFF
--- a/wgs84_utils/CMakeLists.txt
+++ b/wgs84_utils/CMakeLists.txt
@@ -32,6 +32,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 find_package(Eigen3 REQUIRED)
+find_package(Boost REQUIRED)
 
 
 catkin_package(
@@ -56,7 +57,7 @@ include_directories(
 
 file(GLOB_RECURSE headers */*.hpp */*.h)
 
-add_library(wgs84_utils_library src/wgs84_utils/wgs84_utils.cpp)
+add_library(wgs84_utils_library src/wgs84_utils/wgs84_utils.cpp src/wgs84_utils/proj_tools.cpp)
 target_link_libraries(wgs84_utils_library)
 add_dependencies(wgs84_utils_library ${catkin_EXPORTED_TARGETS})
 
@@ -83,11 +84,10 @@ add_dependencies(wgs84_utils_library ${catkin_EXPORTED_TARGETS})
 ## Test ##
 ##########
 
-# SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
-# catkin_add_gtest(transform_maintainer_test test/transform_maintainer_test.cpp)
+catkin_add_gmock(wgs84_uitls_test test/test_main.cpp test/proj_tools_test.cpp)
 
-# target_link_libraries( transform_maintainer_test
-#         wgs84_utils_library
-#         ${Boost_LIBRARIES} 
-#         ${catkin_LIBRARIES}
-#         )
+target_link_libraries( wgs84_uitls_test
+  wgs84_utils_library
+  ${Boost_LIBRARIES} 
+  ${catkin_LIBRARIES}
+)

--- a/wgs84_utils/include/wgs84_utils/proj_tools.h
+++ b/wgs84_utils/include/wgs84_utils/proj_tools.h
@@ -1,0 +1,54 @@
+#pragma once
+/*
+ * Copyright (C) 2021 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+#include <tf2/LinearMath/Quaternion.h>
+#include <string>
+#include "wgs84_utils.h"
+
+namespace wgs84_utils
+{
+namespace proj_tools
+{
+/**
+ * \brief Extracts the +axis field value from a proj string if it exists.
+ *        If the field does not exist then this returns "enu" which is the default assumed by the proj library.
+ *
+ * \param proj_string A proj string following standard proj library notation
+ * \throw std::invalid_argument If the axis tag is provided but is empty such as "+axis=" or "+axis= "
+ *
+ * \return The extracted axis 3 letter field value. For example a string like "+proj=tmerc +lat_0=0.0 +lon_0=0.0
+ * +axis=ned" would return the value "ned"
+ */
+std::string getAxisFromProjString(std::string proj_string);
+
+/**
+ * \brief Returns a 3d rotation to align a provided righthanded proj library compliant +axis specification with an NED
+ * (North East Down) frame at the same location. At the time of this methods creation proj only supported axis
+ * specifications where x and y align with lat/lon in some form. This method only supports right handed axis
+ * orientations at this time such as "enu" and "ned" but NOT "wnu" which would be left handed.
+ *
+ * \param axis The value of an +axis tag extracted from a proj library projection to get rotation to NED from. For
+ * example "enu"
+ * 
+ * \throw std::invalid_arugmnet if provided axis is left handed instead of right handed
+ *
+ * \return The rotation which would need to be applied to the provided axis for it to become and NED axis.
+ *
+ */
+tf2::Quaternion getRotationOfNEDFromProjAxis(const std::string& axis);
+
+}  // namespace proj_tools
+}  // namespace wgs84_utils

--- a/wgs84_utils/src/wgs84_utils/proj_tools.cpp
+++ b/wgs84_utils/src/wgs84_utils/proj_tools.cpp
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2021 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+#include <wgs84_utils/proj_tools.h>
+#include <tf2/LinearMath/Quaternion.h>
+#include <vector>
+#include <string>
+#include <boost/algorithm/string.hpp>
+#include <algorithm>
+
+namespace wgs84_utils
+{
+namespace proj_tools
+{
+std::string getAxisFromProjString(std::string proj_string)
+{
+  boost::erase_all(proj_string, " ");  // Remove white space from string
+
+  std::vector<std::string> strs;
+  boost::split(strs, proj_string, boost::is_any_of("+"));  // Split on + sign used to denote proj parameters
+
+  std::string axis = "enu";  // Default axis alignment is ENU in proj
+
+  for (const auto& param : strs)  // Iterate over proj string parameters until axis parameter is found
+  {
+    size_t axis_pos = param.find("axis=");
+    if (axis_pos != 0)
+    {
+      continue;
+    }
+
+    size_t equal_pos = param.find("=");
+    if (equal_pos >= param.size() - 1)
+    {
+      throw std::invalid_argument("Cannot extract +axis tag as georeference has an +axis tag which "
+                                  "is empty: " +
+                                  param);
+    }
+
+    axis = param.substr(param.find("=") + 1);
+
+    break;  // If axis is found no reason to keep iterating.
+  }
+
+  return axis;
+}
+
+tf2::Quaternion getRotationOfNEDFromProjAxis(const std::string& axis)
+{
+  /*
+
+    Proj Axis notation
+    “e” - Easting
+    “w” - Westing
+    “n” - Northing
+    “s” - Southing
+    “u” - Up
+    “d” - Down
+
+    */
+
+  tf2::Quaternion axis_in_ned;
+
+  // Convert axis into transform with NED frame
+  // Only support right handed coordinate systems at this time
+  if (axis.compare("enu") == 0)
+  {  // East North Up
+
+    axis_in_ned.setRPY(180.0 * wgs84_utils::DEG2RAD, 0,
+                       90.0 * wgs84_utils::DEG2RAD);  // Convert from NED frame using fixed-axis roll pitch yaw
+                                                      // rotations
+  }
+  else if (axis.compare("nwu") == 0)
+  {  // North West Up
+
+    axis_in_ned.setRPY(180.0 * wgs84_utils::DEG2RAD, 0, 0);
+  }
+  else if (axis.compare("wsu") == 0)
+  {  // West South Up
+
+    axis_in_ned.setRPY(180.0 * wgs84_utils::DEG2RAD, 0, -90.0 * wgs84_utils::DEG2RAD);
+  }
+  else if (axis.compare("seu") == 0)
+  {  // South East Up
+
+    axis_in_ned.setRPY(180.0 * wgs84_utils::DEG2RAD, 0, -180.0 * wgs84_utils::DEG2RAD);
+  }
+  else if (axis.compare("ned") == 0)
+  {  // North East Down
+
+    axis_in_ned = tf2::Quaternion::getIdentity();
+  }
+  else if (axis.compare("wnd") == 0)
+  {  // West North Down
+
+    axis_in_ned.setRPY(0, 0, -90.0 * wgs84_utils::DEG2RAD);
+  }
+  else if (axis.compare("swd") == 0)
+  {  // South West Down
+
+    axis_in_ned.setRPY(0, 0, 180.0 * wgs84_utils::DEG2RAD);
+  }
+  else if (axis.compare("esd") == 0)
+  {  // East South Down
+
+    axis_in_ned.setRPY(0, 0, 90.0 * wgs84_utils::DEG2RAD);
+  }
+  else
+  {
+    throw std::invalid_argument("Proj axis to enu conversion only supports projections using right handed coordinate frames");
+  }
+
+  return axis_in_ned.inverse();  // Inverse rotation to get rotations required to come from existing axis to ned
+}
+}  // namespace proj_tools
+}  // namespace wgs84_utils

--- a/wgs84_utils/test/proj_tools_test.cpp
+++ b/wgs84_utils/test/proj_tools_test.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2021 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+#include <gtest/gtest.h>
+#include <wgs84_utils/proj_tools.h>
+
+
+TEST(proj_tools, getAxisFromProjString)
+{
+  std::string base_proj = "+proj=tmerc +lat_0=38.95197911150576 +lon_0=-77.14835128349988 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +geoidgrids=egm96_15.gtx +vunits=m +no_defs";
+
+  std::string axis = wgs84_utils::proj_tools::getAxisFromProjString(base_proj);
+  ASSERT_TRUE(axis.compare("enu") == 0); // Default case
+
+  axis = wgs84_utils::proj_tools::getAxisFromProjString(base_proj + " +axis=enu ");
+  ASSERT_TRUE(axis.compare("enu") == 0);
+
+  axis = wgs84_utils::proj_tools::getAxisFromProjString(base_proj + " +axis = ned ");
+  ASSERT_TRUE(axis.compare("ned") == 0);
+
+  axis = wgs84_utils::proj_tools::getAxisFromProjString(base_proj + " +axis = nwu +h_0=10.0");
+  ASSERT_TRUE(axis.compare("nwu") == 0);
+
+  ASSERT_THROW(wgs84_utils::proj_tools::getAxisFromProjString(base_proj + " +axis = "), std::invalid_argument); // Empty case
+}
+
+void assertNearQuat(const tf2::Quaternion& q1, const tf2::Quaternion& q2, double bounds) {
+  ASSERT_NEAR(q1.x(), q2.x(), bounds);
+  ASSERT_NEAR(q1.y(), q2.y(), bounds);
+  ASSERT_NEAR(q1.z(), q2.z(), bounds);
+  ASSERT_NEAR(q1.w(), q2.w(), bounds);
+}
+
+TEST(proj_tools, getRotationOfNEDFromProjAxis) {
+  tf2::Quaternion rot = wgs84_utils::proj_tools::getRotationOfNEDFromProjAxis("enu");
+
+  tf2::Quaternion solution;
+  solution.setRPY(180.0 * wgs84_utils::DEG2RAD, 0,
+                       90.0 * wgs84_utils::DEG2RAD);
+  solution = solution.inverse();
+
+  assertNearQuat(rot, solution, 0.00001);
+
+  rot = wgs84_utils::proj_tools::getRotationOfNEDFromProjAxis("nwu");
+
+  solution.setRPY(180.0 * wgs84_utils::DEG2RAD, 0, 0);
+  solution = solution.inverse();
+
+  assertNearQuat(rot, solution, 0.00001);
+
+  rot = wgs84_utils::proj_tools::getRotationOfNEDFromProjAxis("wsu");
+
+  solution.setRPY(180.0 * wgs84_utils::DEG2RAD, 0, -90.0 * wgs84_utils::DEG2RAD);
+  solution = solution.inverse();
+
+  assertNearQuat(rot, solution, 0.00001);
+
+  rot = wgs84_utils::proj_tools::getRotationOfNEDFromProjAxis("seu");
+
+  solution.setRPY(180.0 * wgs84_utils::DEG2RAD, 0, -180.0 * wgs84_utils::DEG2RAD);
+  solution = solution.inverse();
+
+  assertNearQuat(rot, solution, 0.00001);
+
+  rot = wgs84_utils::proj_tools::getRotationOfNEDFromProjAxis("ned");
+
+  solution = tf2::Quaternion::getIdentity();
+  solution = solution.inverse();
+
+  assertNearQuat(rot, solution, 0.00001);
+
+  rot = wgs84_utils::proj_tools::getRotationOfNEDFromProjAxis("wnd");
+
+  solution.setRPY(0, 0, -90.0 * wgs84_utils::DEG2RAD);
+  solution = solution.inverse();
+
+  assertNearQuat(rot, solution, 0.00001);
+
+  rot = wgs84_utils::proj_tools::getRotationOfNEDFromProjAxis("swd");
+
+  solution.setRPY(0, 0, 180.0 * wgs84_utils::DEG2RAD);
+  solution = solution.inverse();
+
+  assertNearQuat(rot, solution, 0.00001);
+
+  rot = wgs84_utils::proj_tools::getRotationOfNEDFromProjAxis("esd");
+
+  solution.setRPY(0, 0, 90.0 * wgs84_utils::DEG2RAD);
+  solution = solution.inverse();
+
+  assertNearQuat(rot, solution, 0.00001);
+
+  ASSERT_THROW(wgs84_utils::proj_tools::getRotationOfNEDFromProjAxis("exception"), std::invalid_argument);
+  
+}

--- a/wgs84_utils/test/test_main.cpp
+++ b/wgs84_utils/test/test_main.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2021 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <gtest/gtest.h>
+#include <ros/ros.h>
+
+// Run all the tests
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  ros::Time::init();
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR is in support of https://github.com/usdot-fhwa-stol/carma-platform/issues/1285
A new proj_tools namespace is added to wgs84_utils which contains two methods for handling the optional +axis field in proj4 strings. This field creates different axis orientations. The provided functions help to convert these orientations into a common NED frame so that heading reports from GPS can be properly mapped into the map frame. 
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/1285
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
See linked issue
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Blue lexus (in progress)
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.