### PR TITLE
68 - Add can_msgs as dependency for cav_driver_utils

### DIFF
--- a/cav_driver_utils/CMakeLists.txt
+++ b/cav_driver_utils/CMakeLists.txt
@@ -21,6 +21,7 @@ set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 
 find_package(catkin REQUIRED COMPONENTS
   bondcpp
+  can_msgs
   cav_msgs
   cav_srvs
   roscpp
@@ -41,7 +42,7 @@ find_package(Boost REQUIRED system)
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES driver_application cav_socketcan_interface ros_socketcan_interface driver_wrapper
-  CATKIN_DEPENDS bondcpp cav_msgs cav_srvs roscpp std_msgs
+  CATKIN_DEPENDS bondcpp can_msgs cav_msgs cav_srvs roscpp std_msgs
 #  DEPENDS system_lib
 )
 

--- a/cav_driver_utils/package.xml
+++ b/cav_driver_utils/package.xml
@@ -14,6 +14,7 @@
   <depend>cav_srvs</depend>
   <depend>roscpp</depend>
   <depend>std_msgs</depend>
+  <depend>can_msgs</depend>
 
 
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
<!--- Describe your changes in detail -->
Adds the `can_msgs` package as a dependency for the `cav_driver_utils` package. The `cav_driver_utils` package can now be built using `catkin_make` even if the `can_msgs` package has not already been built. `catkin_make` will build `can_msgs` while building `cav_driver_utils`. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes usdot-fhwa-stol/carma-utils#68.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Without the dependency listed, developers would have to attempt to build `cav_driver_utils` to discover the issue. They would then have to build `can_msgs` before building `cav_driver_utils`, which should have been handled by the ROS build system automatically.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`cav_driver_utils` package has been built in a new ROS workspace with only `carma-utils` and `carma-msgs` repositories added.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.