### PR TITLE
Update ROS Noetic branch to C++14

### DIFF
--- a/carma_utils/CMakeLists.txt
+++ b/carma_utils/CMakeLists.txt
@@ -16,8 +16,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(carma_utils)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++11)
+## Compile as C++14, supported in ROS Noetic and newer
+add_compile_options(-std=c++14)
 set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 

--- a/cav_driver_utils/CMakeLists.txt
+++ b/cav_driver_utils/CMakeLists.txt
@@ -15,7 +15,7 @@
 
 cmake_minimum_required(VERSION 2.8.3)
 project(cav_driver_utils)
-add_compile_options(-std=c++11)
+add_compile_options(-std=c++14)
 set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 

--- a/driver_shutdown/CMakeLists.txt
+++ b/driver_shutdown/CMakeLists.txt
@@ -15,8 +15,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(driver_shutdown)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++11)
+## Compile as C++14, supported in ROS Noetic and newer
+add_compile_options(-std=c++14)
 set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 

--- a/motion_predict/CMakeLists.txt
+++ b/motion_predict/CMakeLists.txt
@@ -16,8 +16,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(motion_predict)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++11)
+## Compile as C++14, supported in ROS Noetic and newer
+add_compile_options(-std=c++14)
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)

--- a/sigpack/CMakeLists.txt
+++ b/sigpack/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(sigpack)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++11)
+## Compile as C++14, supported in ROS Noetic and newer
+add_compile_options(-std=c++14)
 set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 

--- a/sigpack/demo_c++/Makefile
+++ b/sigpack/demo_c++/Makefile
@@ -1,5 +1,5 @@
 CXX = g++
-CXX_FLAGS = -Wall -std=c++11 -DHAVE_FFTW -I../sigpack -larmadillo -lfftw3
+CXX_FLAGS = -Wall -std=c++14 -DHAVE_FFTW -I../sigpack -larmadillo -lfftw3
 
 %: %.cpp
 	@echo '+++++++++++++++++++++++++++++++++++++++++++++'

--- a/sigpack/test/Makefile
+++ b/sigpack/test/Makefile
@@ -1,5 +1,5 @@
 CXX = g++
-CXX_FLAGS = -Wall -ggdb -std=c++11 -DHAVE_FFTW -I../sigpack -larmadillo -lfftw3
+CXX_FLAGS = -Wall -ggdb -std=c++14 -DHAVE_FFTW -I../sigpack -larmadillo -lfftw3
 
 %: %.cpp
 	@echo '+++++++++++++++++++++++++++++++++++++++++++++'

--- a/socketcan_bridge/CMakeLists.txt
+++ b/socketcan_bridge/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.8.3)
-add_compile_options(-std=c++11)
+add_compile_options(-std=c++14)
 set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 project(socketcan_bridge)

--- a/uncertainty_tools/CMakeLists.txt
+++ b/uncertainty_tools/CMakeLists.txt
@@ -16,8 +16,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(uncertainty_tools)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++11)
+## Compile as C++14, supported in ROS Noetic and newer
+add_compile_options(-std=c++14)
 set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 

--- a/wgs84_utils/CMakeLists.txt
+++ b/wgs84_utils/CMakeLists.txt
@@ -16,8 +16,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(wgs84_utils)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++11)
+## Compile as C++14, supported in ROS Noetic and newer
+add_compile_options(-std=c++14)
 set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 


### PR DESCRIPTION
# PR Details
## Description

Update the CMakeLists.txt files to specify c++14 instead of C++11. Also, must use at least cmake 3.1 to use CMAKE_CXX_STANDARD.

## Motivation and Context

Using C++ 14 to compile the CARMA source code on Ubuntu 20.04.

## How Has This Been Tested?

Full build and checking the output logs for C++ 14 usage.

## Checklist:
- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.