### PR TITLE
Apply fix for issue #68 to `noetic/develop` branch

### DIFF
--- a/cav_driver_utils/CMakeLists.txt
+++ b/cav_driver_utils/CMakeLists.txt
@@ -21,6 +21,7 @@ set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 
 find_package(catkin REQUIRED COMPONENTS
   bondcpp
+  can_msgs
   cav_msgs
   cav_srvs
   roscpp
@@ -41,7 +42,7 @@ find_package(Boost REQUIRED system)
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES driver_application cav_socketcan_interface ros_socketcan_interface driver_wrapper
-  CATKIN_DEPENDS bondcpp cav_msgs cav_srvs roscpp std_msgs
+  CATKIN_DEPENDS bondcpp can_msgs cav_msgs cav_srvs roscpp std_msgs
 #  DEPENDS system_lib
 )
 

--- a/cav_driver_utils/package.xml
+++ b/cav_driver_utils/package.xml
@@ -14,6 +14,7 @@
   <depend>cav_srvs</depend>
   <depend>roscpp</depend>
   <depend>std_msgs</depend>
+  <depend>can_msgs</depend>
 
 
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR fixes #68 for the `noetic/develop` branch, which is also affected.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #68 for the `noetic/develop` branch.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Issue #68 applies to both `develop` and `noetic/develop` branches, but PR #69 was only applied to `develop`. The `develop` and `noetic/develop` branches have diverged to the point where they cannot be automatically merged, so this PR applies the same fix for #68 but in a separate PR.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`cav_driver_utils` package has been built in a new ROS workspace with only `carma-utils` and `carma-msgs` repositories added.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.