### PR TITLE
Fix warning "warning: control reaches end of non-void function" from …

### DIFF
--- a/carma_utils/include/carma_utils/internal/CARMANodeHandle.tpp
+++ b/carma_utils/include/carma_utils/internal/CARMANodeHandle.tpp
@@ -64,6 +64,7 @@ namespace ros {
       } catch(const std::exception& e) {
         handleException(e);
       }
+      return false;
     };
 
     return wrappedFunc;


### PR DESCRIPTION
…CARMANodeHandle.tpp

<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Resolves https://github.com/usdot-fhwa-stol/carma-platform/issues/1343 by returning false to indicate failed service call if a top level exception is caught. 

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/1343
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Clean build
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Build
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.