### PR TITLE
Feature/component log level support

### DIFF
--- a/carma_ros2_utils/CMakeLists.txt
+++ b/carma_ros2_utils/CMakeLists.txt
@@ -23,7 +23,7 @@ ament_auto_add_library(lifecycle_component_wrapper SHARED
   src/lifecycle_component_wrapper.cpp
 )
 
-ament_auto_add_library(component_manager SHARED
+ament_auto_add_library(carma_component_manager SHARED
   src/component_manager.cpp
 )
 
@@ -35,11 +35,11 @@ ament_auto_add_executable(lifecycle_component_wrapper_mt
   src/lifecycle_component_wrapper_mt.cpp
 )
 
-ament_auto_add_executable(component_container
+ament_auto_add_executable(carma_component_container
   src/component_container.cpp
 )
 
-ament_auto_add_executable(component_container_mt
+ament_auto_add_executable(carma_component_container_mt
   src/component_container_mt.cpp
 )
 
@@ -58,12 +58,12 @@ target_link_libraries(lifecycle_component_wrapper_mt
   ${PROJECT_NAME}
 )
 
-target_link_libraries(component_container
-  component_manager
+target_link_libraries(carma_component_container
+  carma_component_manager
 )
 
-target_link_libraries(component_container_mt
-  component_manager
+target_link_libraries(carma_component_container_mt
+  carma_component_manager
 )
 
 if(BUILD_TESTING)

--- a/carma_ros2_utils/CMakeLists.txt
+++ b/carma_ros2_utils/CMakeLists.txt
@@ -23,12 +23,24 @@ ament_auto_add_library(lifecycle_component_wrapper SHARED
   src/lifecycle_component_wrapper.cpp
 )
 
+ament_auto_add_library(component_manager SHARED
+  src/component_manager.cpp
+)
+
 ament_auto_add_executable(lifecycle_component_wrapper_st
   src/lifecycle_component_wrapper_st.cpp
 )
 
 ament_auto_add_executable(lifecycle_component_wrapper_mt
   src/lifecycle_component_wrapper_mt.cpp
+)
+
+ament_auto_add_executable(component_container
+  src/component_container.cpp
+)
+
+ament_auto_add_executable(component_container_mt
+  src/component_container_mt.cpp
 )
 
 # Link local targets
@@ -44,6 +56,14 @@ target_link_libraries(lifecycle_component_wrapper_st
 target_link_libraries(lifecycle_component_wrapper_mt
   lifecycle_component_wrapper
   ${PROJECT_NAME}
+)
+
+target_link_libraries(component_container
+  component_manager
+)
+
+target_link_libraries(component_container_mt
+  component_manager
 )
 
 if(BUILD_TESTING)

--- a/carma_ros2_utils/include/carma_ros2_utils/carma_lifecycle_node.hpp
+++ b/carma_ros2_utils/include/carma_ros2_utils/carma_lifecycle_node.hpp
@@ -62,6 +62,12 @@ namespace carma_ros2_utils
   template<class T>
   using SubPtr = typename rclcpp::Subscription<T>::SharedPtr;
 
+  template<class T>
+  using ServicePtr = typename rclcpp::Service<T>::SharedPtr;
+
+  template<class T>
+  using ClientPtr = typename rclcpp::Client<T>::SharedPtr;
+
   /**
  * \brief The CarmaLifecycleNode provides default exception handling and SystemAlert handling for components in carma-platform.
  *        All new nodes in carma-platform are expected to be built off CarmaLifecycleNode and implemented as components. 

--- a/carma_ros2_utils/include/carma_ros2_utils/component_manager.hpp
+++ b/carma_ros2_utils/include/carma_ros2_utils/component_manager.hpp
@@ -1,0 +1,254 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Modifications copyright (C) 2021 Leidos
+ * - Converted into CARMA Component Manager by adding log-level support
+ * 
+ */ 
+
+/** \mainpage rclcpp_components: Package containing tools for dynamically loadable components.
+ *
+ * - ComponentManager: Node to manage components. It has the services to load, unload and list
+ *   current components.
+ *   - rclcpp_components/component_manager.hpp)
+ * - Node factory: The NodeFactory interface is used by the class loader to instantiate components.
+ *   - rclcpp_components/node_factory.hpp)
+ *   - It allows for classes not derived from `rclcpp::Node` to be used as components.
+ *   - It allows derived constructors to be called when components are loaded.
+ *
+ * Some useful abstractions and utilities:
+ * - [RCLCPP_COMPONENTS_REGISTER_NODE: Register a component that can be dynamically loaded
+ *   at runtime.
+ *   - (include/rclcpp_components/register_node_macro.hpp)
+ *
+ * Some useful internal abstractions and utilities:
+ * - Macros for controlling symbol visibility on the library
+ *   - rclcpp_components/visibility_control.h
+ *
+ * Package containing CMake tools for register components:
+ * - `rclcpp_components_register_node` Register an rclcpp component with the ament resource index
+ *    and create an executable.
+ * - `rclcpp_components_register_nodes` Register an rclcpp component with the ament resource index.
+ *    The passed library can contain multiple nodes each registered via macro.
+ */
+
+#ifndef RCLCPP_COMPONENTS__COMPONENT_MANAGER_HPP__
+#define RCLCPP_COMPONENTS__COMPONENT_MANAGER_HPP__
+
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "composition_interfaces/srv/load_node.hpp"
+#include "composition_interfaces/srv/unload_node.hpp"
+#include "composition_interfaces/srv/list_nodes.hpp"
+
+#include "rclcpp/executor.hpp"
+#include "rclcpp/node_options.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+#include "rclcpp_components/node_factory.hpp"
+#include "rclcpp_components/visibility_control.hpp"
+
+namespace class_loader
+{
+class ClassLoader;
+}  // namespace class_loader
+
+namespace carma_ros2_utils
+{
+
+/// Thrown when an error happens in the component Manager class.
+class ComponentManagerException : public std::runtime_error
+{
+public:
+  explicit ComponentManagerException(const std::string & error_desc)
+  : std::runtime_error(error_desc) {}
+};
+
+/// ComponentManager handles the services to load, unload, and get the list of loaded components.
+class ComponentManager : public rclcpp::Node
+{
+public:
+  using LoadNode = composition_interfaces::srv::LoadNode;
+  using UnloadNode = composition_interfaces::srv::UnloadNode;
+  using ListNodes = composition_interfaces::srv::ListNodes;
+
+  /// Represents a component resource.
+  /**
+   * Is a pair of class name (for class loader) and library path (absolute)
+   */
+  using ComponentResource = std::pair<std::string, std::string>;
+
+  /// Default constructor
+  /**
+   * Initializes the component manager. It creates the services: load node, unload node
+   * and list nodes.
+   *
+   * \param executor the executor which will spin the node.
+   * \param node_name the name of the node that the data originates from.
+   * \param node_options additional options to control creation of the node.
+   */
+  RCLCPP_COMPONENTS_PUBLIC
+  ComponentManager(
+    std::weak_ptr<rclcpp::Executor> executor,
+    std::string node_name = "ComponentManager",
+    const rclcpp::NodeOptions & node_options = rclcpp::NodeOptions()
+    .start_parameter_services(false)
+    .start_parameter_event_publisher(false));
+
+  RCLCPP_COMPONENTS_PUBLIC
+  virtual ~ComponentManager();
+
+  /// Return a list of valid loadable components in a given package.
+  /**
+   * \param package_name name of the package
+   * \param resource_index name of the executable
+   * \throws ComponentManagerException if the resource was not found or a invalid resource entry
+   * \return a list of component resources
+   */
+  RCLCPP_COMPONENTS_PUBLIC
+  virtual std::vector<ComponentResource>
+  get_component_resources(
+    const std::string & package_name,
+    const std::string & resource_index = "rclcpp_components") const;
+
+  /// Instantiate a component from a dynamic library.
+  /**
+   * \param resource a component resource (class name + library path)
+   * \return a NodeFactory interface
+   */
+  RCLCPP_COMPONENTS_PUBLIC
+  virtual std::shared_ptr<rclcpp_components::NodeFactory>
+  create_component_factory(const ComponentResource & resource);
+
+protected:
+  /// Create node options for loaded component
+  /**
+   * \param request information with the node to load
+   * \return node options
+   */
+  RCLCPP_COMPONENTS_PUBLIC
+  virtual rclcpp::NodeOptions
+  create_node_options(const std::shared_ptr<LoadNode::Request> request);
+
+  /// Service callback to load a new node in the component
+  /**
+   * This function allows to add parameters, remap rules, a specific node, name a namespace
+   * and/or additional arguments.
+   *
+   * \param request_header unused
+   * \param request information with the node to load
+   * \param response
+   * \throws std::overflow_error if node_id suffers an overflow. Very unlikely to happen at 1 kHz
+   *   (very optimistic rate). it would take 585 years.
+   * \throws ComponentManagerException In the case that the component constructor throws an
+   *   exception, rethrow into the following catch block.
+   */
+  RCLCPP_COMPONENTS_PUBLIC
+  virtual void
+  on_load_node(
+    const std::shared_ptr<rmw_request_id_t> request_header,
+    const std::shared_ptr<LoadNode::Request> request,
+    std::shared_ptr<LoadNode::Response> response);
+
+  /**
+   * \deprecated Use on_load_node() instead
+   */
+  [[deprecated("Use on_load_node() instead")]]
+  RCLCPP_COMPONENTS_PUBLIC
+  virtual void
+  OnLoadNode(
+    const std::shared_ptr<rmw_request_id_t> request_header,
+    const std::shared_ptr<LoadNode::Request> request,
+    std::shared_ptr<LoadNode::Response> response)
+  {
+    on_load_node(request_header, request, response);
+  }
+
+  /// Service callback to unload a node in the component
+  /**
+   * \param request_header unused
+   * \param request unique identifier to remove from the component
+   * \param response true on the success field if the node unload was succefully, otherwise false
+   *   and the error_message field contains the error.
+   */
+  RCLCPP_COMPONENTS_PUBLIC
+  virtual void
+  on_unload_node(
+    const std::shared_ptr<rmw_request_id_t> request_header,
+    const std::shared_ptr<UnloadNode::Request> request,
+    std::shared_ptr<UnloadNode::Response> response);
+
+  /**
+   * \deprecated Use on_unload_node() instead
+   */
+  [[deprecated("Use on_unload_node() instead")]]
+  RCLCPP_COMPONENTS_PUBLIC
+  virtual void
+  OnUnloadNode(
+    const std::shared_ptr<rmw_request_id_t> request_header,
+    const std::shared_ptr<UnloadNode::Request> request,
+    std::shared_ptr<UnloadNode::Response> response)
+  {
+    on_unload_node(request_header, request, response);
+  }
+
+  /// Service callback to get the list of nodes in the component
+  /**
+   * Return a two list: one with the unique identifiers and other with full name of the nodes.
+   *
+   * \param request_header unused
+   * \param request unused
+   * \param response list with the unique ids and full node names
+   */
+  RCLCPP_COMPONENTS_PUBLIC
+  virtual void
+  on_list_nodes(
+    const std::shared_ptr<rmw_request_id_t> request_header,
+    const std::shared_ptr<ListNodes::Request> request,
+    std::shared_ptr<ListNodes::Response> response);
+
+  /**
+   * \deprecated Use on_list_nodes() instead
+   */
+  [[deprecated("Use on_list_nodes() instead")]]
+  RCLCPP_COMPONENTS_PUBLIC
+  virtual void
+  OnListNodes(
+    const std::shared_ptr<rmw_request_id_t> request_header,
+    const std::shared_ptr<ListNodes::Request> request,
+    std::shared_ptr<ListNodes::Response> response)
+  {
+    on_list_nodes(request_header, request, response);
+  }
+
+private:
+  std::weak_ptr<rclcpp::Executor> executor_;
+
+  uint64_t unique_id_ {1};
+  std::map<std::string, std::unique_ptr<class_loader::ClassLoader>> loaders_;
+  std::map<uint64_t, rclcpp_components::NodeInstanceWrapper> node_wrappers_;
+
+  rclcpp::Service<LoadNode>::SharedPtr loadNode_srv_;
+  rclcpp::Service<UnloadNode>::SharedPtr unloadNode_srv_;
+  rclcpp::Service<ListNodes>::SharedPtr listNodes_srv_;
+};
+
+}  // namespace rclcpp_components
+
+#endif  // RCLCPP_COMPONENTS__COMPONENT_MANAGER_HPP__

--- a/carma_ros2_utils/src/component_container.cpp
+++ b/carma_ros2_utils/src/component_container.cpp
@@ -1,0 +1,35 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Modifications copyright (C) 2021 Leidos
+ * - Converted into CARMA Component Container by adding log-level support
+ * 
+ */ 
+
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "carma_ros2_utils/component_manager.hpp"
+
+int main(int argc, char * argv[])
+{
+  /// Component container with a single-threaded executor.
+  rclcpp::init(argc, argv);
+  auto exec = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+  auto node = std::make_shared<carma_ros2_utils::ComponentManager>(exec);
+  exec->add_node(node);
+  exec->spin();
+}

--- a/carma_ros2_utils/src/component_container_mt.cpp
+++ b/carma_ros2_utils/src/component_container_mt.cpp
@@ -1,0 +1,35 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Modifications copyright (C) 2021 Leidos
+ * - Converted into CARMA Component Container by adding log-level support
+ * 
+ */ 
+
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "carma_ros2_utils/component_manager.hpp"
+
+int main(int argc, char * argv[])
+{
+  /// Component container with a multi-threaded executor.
+  rclcpp::init(argc, argv);
+  auto exec = std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
+  auto node = std::make_shared<carma_ros2_utils::ComponentManager>(exec);
+  exec->add_node(node);
+  exec->spin();
+}

--- a/carma_ros2_utils/src/component_manager.cpp
+++ b/carma_ros2_utils/src/component_manager.cpp
@@ -14,11 +14,11 @@
 
 /**
  * Modifications copyright (C) 2021 Leidos
- * - Converted into Lifecycle Component Wrapper
+ * - Converted into CARMA Component Manager by adding log-level support
  * 
  */ 
 
-#include "carma_ros2_utils/lifecycle_component_wrapper.hpp"
+#include "carma_ros2_utils/component_manager.hpp"
 
 #include <functional>
 #include <memory>
@@ -26,43 +26,43 @@
 #include <utility>
 #include <vector>
 
-#include <ament_index_cpp/get_resource.hpp>
-#include <class_loader/class_loader.hpp>
-#include <rcpputils/filesystem_helper.hpp>
-#include <rcpputils/split.hpp>
+#include "ament_index_cpp/get_resource.hpp"
+#include "class_loader/class_loader.hpp"
+#include "rcpputils/filesystem_helper.hpp"
+#include "rcpputils/split.hpp"
 
 using namespace std::placeholders;
+
+/////
+// CARMA CHANGE START
+using namespace rclcpp_components;
 
 namespace carma_ros2_utils
 {
 
-///// CARMA CHANGE /////
-LifecycleComponentWrapper::LifecycleComponentWrapper(const rclcpp::NodeOptions & node_options)
-: carma_ros2_utils::CarmaLifecycleNode(node_options)
+/////
+// CARMA CHANGE END
+/////
+
+ComponentManager::ComponentManager(
+  std::weak_ptr<rclcpp::Executor> executor,
+  std::string node_name,
+  const rclcpp::NodeOptions & node_options)
+: Node(std::move(node_name), node_options),
+  executor_(executor)
 {
-  // Do nothing
-}
-
-void LifecycleComponentWrapper::initialize(std::weak_ptr<rclcpp::Executor> executor) {
-  executor_ = executor;
-
   loadNode_srv_ = create_service<LoadNode>(
     "~/_container/load_node",
-    std::bind(&LifecycleComponentWrapper::on_load_node, this, _1, _2, _3, boost::none));
-
+    std::bind(&ComponentManager::on_load_node, this, _1, _2, _3));
   unloadNode_srv_ = create_service<UnloadNode>(
     "~/_container/unload_node",
-    std::bind(&LifecycleComponentWrapper::on_unload_node, this, _1, _2, _3));
-
+    std::bind(&ComponentManager::on_unload_node, this, _1, _2, _3));
   listNodes_srv_ = create_service<ListNodes>(
     "~/_container/list_nodes",
-    std::bind(&LifecycleComponentWrapper::on_list_nodes, this, _1, _2, _3));
-
+    std::bind(&ComponentManager::on_list_nodes, this, _1, _2, _3));
 }
 
-////// END CARMA CHANGE /////
-
-LifecycleComponentWrapper::~LifecycleComponentWrapper()
+ComponentManager::~ComponentManager()
 {
   if (node_wrappers_.size()) {
     RCLCPP_DEBUG(get_logger(), "Removing components from executor");
@@ -74,8 +74,8 @@ LifecycleComponentWrapper::~LifecycleComponentWrapper()
   }
 }
 
-std::vector<LifecycleComponentWrapper::ComponentResource>
-LifecycleComponentWrapper::get_component_resources(
+std::vector<ComponentManager::ComponentResource>
+ComponentManager::get_component_resources(
   const std::string & package_name, const std::string & resource_index) const
 {
   std::string content;
@@ -84,7 +84,7 @@ LifecycleComponentWrapper::get_component_resources(
     !ament_index_cpp::get_resource(
       resource_index, package_name, content, &base_path))
   {
-    throw rclcpp_components::ComponentManagerException("Could not find requested resource in ament index");
+    throw ComponentManagerException("Could not find requested resource in ament index");
   }
 
   std::vector<ComponentResource> resources;
@@ -92,7 +92,7 @@ LifecycleComponentWrapper::get_component_resources(
   for (const auto & line : lines) {
     std::vector<std::string> parts = rcpputils::split(line, ';');
     if (parts.size() != 2) {
-      throw rclcpp_components::ComponentManagerException("Invalid resource entry");
+      throw ComponentManagerException("Invalid resource entry");
     }
 
     std::string library_path = parts[1];
@@ -105,7 +105,7 @@ LifecycleComponentWrapper::get_component_resources(
 }
 
 std::shared_ptr<rclcpp_components::NodeFactory>
-LifecycleComponentWrapper::create_component_factory(const ComponentResource & resource)
+ComponentManager::create_component_factory(const ComponentResource & resource)
 {
   std::string library_path = resource.second;
   std::string class_name = resource.first;
@@ -117,9 +117,9 @@ LifecycleComponentWrapper::create_component_factory(const ComponentResource & re
     try {
       loaders_[library_path] = std::make_unique<class_loader::ClassLoader>(library_path);
     } catch (const std::exception & ex) {
-      throw rclcpp_components::ComponentManagerException("Failed to load library: " + std::string(ex.what()));
+      throw ComponentManagerException("Failed to load library: " + std::string(ex.what()));
     } catch (...) {
-      throw rclcpp_components::ComponentManagerException("Failed to load library");
+      throw ComponentManagerException("Failed to load library");
     }
   }
   loader = loaders_[library_path].get();
@@ -136,7 +136,7 @@ LifecycleComponentWrapper::create_component_factory(const ComponentResource & re
 }
 
 rclcpp::NodeOptions
-LifecycleComponentWrapper::create_node_options(const std::shared_ptr<LoadNode::Request> request)
+ComponentManager::create_node_options(const std::shared_ptr<LoadNode::Request> request)
 {
   std::vector<rclcpp::Parameter> parameters;
   for (const auto & p : request->parameters) {
@@ -170,11 +170,12 @@ LifecycleComponentWrapper::create_node_options(const std::shared_ptr<LoadNode::R
     const rclcpp::Parameter extra_argument = rclcpp::Parameter::from_parameter_msg(a);
     if (extra_argument.get_name() == "use_intra_process_comms") {
       if (extra_argument.get_type() != rclcpp::ParameterType::PARAMETER_BOOL) {
-        throw rclcpp_components::ComponentManagerException(
+        throw ComponentManagerException(
                 "Extra component argument 'use_intra_process_comms' must be a boolean");
       }
       options.use_intra_process_comms(extra_argument.get_value<bool>());
     }
+
     /////
     // CARMA CHANGE START
     /////
@@ -183,7 +184,7 @@ LifecycleComponentWrapper::create_node_options(const std::shared_ptr<LoadNode::R
     // After the loop completes the list will be reapplied to this component's options
     if (extra_argument.get_name() == "log-level") {
       if (extra_argument.get_type() != rclcpp::ParameterType::PARAMETER_STRING) {
-        throw rclcpp_components::ComponentManagerException(
+        throw ComponentManagerException(
           "Extra component argument 'log-level' must be a string");
       }
 
@@ -202,35 +203,12 @@ LifecycleComponentWrapper::create_node_options(const std::shared_ptr<LoadNode::R
 }
 
 void
-LifecycleComponentWrapper::on_load_node(
+ComponentManager::on_load_node(
   const std::shared_ptr<rmw_request_id_t> request_header,
   const std::shared_ptr<LoadNode::Request> request,
-  std::shared_ptr<LoadNode::Response> response, boost::optional<uint64_t> internal_id)
+  std::shared_ptr<LoadNode::Response> response)
 {
   (void) request_header;
-
-  ///// CARMA CHANGE /////
-  // If this was an external request and we are NOT in the ACTIVE state
-  // then we should not load the node and simply cache it for load on activate
-  if (!internal_id && get_current_state().id() != lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE) {
-    
-    RCLCPP_INFO_STREAM(get_logger(), "Got request to load node: " << request->node_name <<
-      " but we are not in the active state, caching for later lifecycle based activation.");
-
-    auto node_id = unique_id_++; // Store and update the unique id
-     
-    load_node_requests_.emplace(node_id, std::make_pair(*request_header, *request));
-
-    // NOTE: This is a bit of a hack, but we need to return a valid response
-    response->unique_id = node_id;
-    response->success = true;
-
-    return;
-  }
-
-  // This is an internal request, or we are in the active state, so we can actually load the node
-
-  ///// END CARMA CHANGE /////
 
   try {
     auto resources = get_component_resources(request->package_name);
@@ -246,11 +224,7 @@ LifecycleComponentWrapper::on_load_node(
       }
 
       auto options = create_node_options(request);
-      ///// CARMA CHANGE /////
-      // If a id was provided then we are an internal request and we should use it
-      // else update our unique id counter and set the node id to that
-      auto node_id = internal_id ? internal_id.get() : unique_id_++;
-      ///// END CARMA CHANGE /////
+      auto node_id = unique_id_++;
 
       if (0 == node_id) {
         // This puts a technical limit on the number of times you can add a component.
@@ -268,12 +242,12 @@ LifecycleComponentWrapper::on_load_node(
       } catch (const std::exception & ex) {
         // In the case that the component constructor throws an exception,
         // rethrow into the following catch block.
-        throw rclcpp_components::ComponentManagerException(
+        throw ComponentManagerException(
                 "Component constructor threw an exception: " + std::string(ex.what()));
       } catch (...) {
         // In the case that the component constructor throws an exception,
         // rethrow into the following catch block.
-        throw rclcpp_components::ComponentManagerException("Component constructor threw an exception");
+        throw ComponentManagerException("Component constructor threw an exception");
       }
 
       auto node = node_wrappers_[node_id].get_node_base_interface();
@@ -291,7 +265,7 @@ LifecycleComponentWrapper::on_load_node(
       request->plugin_name.c_str());
     response->error_message = "Failed to find class with the requested plugin name.";
     response->success = false;
-  } catch (const rclcpp_components::ComponentManagerException & ex) {
+  } catch (const ComponentManagerException & ex) {
     RCLCPP_ERROR(get_logger(), "%s", ex.what());
     response->error_message = ex.what();
     response->success = false;
@@ -299,21 +273,12 @@ LifecycleComponentWrapper::on_load_node(
 }
 
 void
-LifecycleComponentWrapper::on_unload_node(
+ComponentManager::on_unload_node(
   const std::shared_ptr<rmw_request_id_t> request_header,
   const std::shared_ptr<UnloadNode::Request> request,
   std::shared_ptr<UnloadNode::Response> response)
 {
   (void) request_header;
-
-  ///// CARMA CHANGE /////
-  // Before unloading the node we need to check if it still exists in our load cache. If it does then remove it.
-  if (load_node_requests_.find(request->unique_id) != load_node_requests_.end()) {
-
-    load_node_requests_.erase(request->unique_id);
-  }
-
-  ///// END CARMA CHANGE /////
 
   auto wrapper = node_wrappers_.find(request->unique_id);
 
@@ -333,7 +298,7 @@ LifecycleComponentWrapper::on_unload_node(
 }
 
 void
-LifecycleComponentWrapper::on_list_nodes(
+ComponentManager::on_list_nodes(
   const std::shared_ptr<rmw_request_id_t> request_header,
   const std::shared_ptr<ListNodes::Request> request,
   std::shared_ptr<ListNodes::Response> response)
@@ -348,84 +313,4 @@ LifecycleComponentWrapper::on_list_nodes(
   }
 }
 
-///// CARMA CHANGE /////
-
-carma_ros2_utils::CallbackReturn LifecycleComponentWrapper::handle_on_activate(const rclcpp_lifecycle::State &) {
-
-  bool success = true;
-
-  for (auto & request : load_node_requests_) {
-    
-    auto response = std::make_shared<LoadNode::Response>();
-    auto header = std::make_shared<rmw_request_id_t>(request.second.first);
-    auto req = std::make_shared<LoadNode::Request>(request.second.second);
-    on_load_node(header, req, response, request.first);
-
-    if (!response->success) {
-
-      RCLCPP_ERROR_STREAM(get_logger(), "Failed to load node: " << response->error_message);
-
-      success = false;
-    }
-  }
-  load_node_requests_.clear();
-
-  return success ? carma_ros2_utils::CallbackReturn::SUCCESS : carma_ros2_utils::CallbackReturn::FAILURE;
-}
-
-carma_ros2_utils::CallbackReturn LifecycleComponentWrapper::handle_on_deactivate(const rclcpp_lifecycle::State &) {
-
-  return unload_all_nodes() ? carma_ros2_utils::CallbackReturn::SUCCESS : carma_ros2_utils::CallbackReturn::FAILURE;
-
-}
-
-carma_ros2_utils::CallbackReturn LifecycleComponentWrapper::handle_on_cleanup(const rclcpp_lifecycle::State &) {
-
-  return unload_all_nodes() ? carma_ros2_utils::CallbackReturn::SUCCESS : carma_ros2_utils::CallbackReturn::FAILURE;
-
-}
-
-carma_ros2_utils::CallbackReturn LifecycleComponentWrapper::handle_on_error(const rclcpp_lifecycle::State &, const std::string &) {
-
-  return unload_all_nodes() ? carma_ros2_utils::CallbackReturn::SUCCESS : carma_ros2_utils::CallbackReturn::FAILURE;
-}
-
-carma_ros2_utils::CallbackReturn LifecycleComponentWrapper::handle_on_shutdown(const rclcpp_lifecycle::State &) {
-
-  return unload_all_nodes() ? carma_ros2_utils::CallbackReturn::SUCCESS : carma_ros2_utils::CallbackReturn::FAILURE;
-}
-
-bool LifecycleComponentWrapper::unload_all_nodes() {
-  bool success = true;
-
-  // On deactivation we will unload all nodes that are currently tracked
-  // We use an iterator loop here because we are modifying the node_wrappers_ map while iterating via the on_unload_node callback
-  for (auto it = node_wrappers_.cbegin(), next_it = it; it != node_wrappers_.cend(); it = next_it)
-  {
-    ++next_it;
-
-    auto request = std::make_shared<UnloadNode::Request>();
-    request->unique_id = it->first;
-
-    auto response = std::make_shared<UnloadNode::Response>();
-      
-
-    // NOTE: This call will erase "it" so do not access it beyond this line
-    on_unload_node(std::make_shared<rmw_request_id_t>(),
-                  request, response); // Unload our node
-
-    if (!response->success) {
-
-      RCLCPP_ERROR_STREAM(get_logger(), "Failed to unload node: " << response->error_message);
-
-      success = false; // If one of the nodes failed to unload we will track this and return a transition failure
-                       // However, to improve system stability we will continue to unload the rest of the nodes
-    }
-  }
-
-  return success;
-}
-
-///// END CARMA CHANGE /////
-
-}  // namespace carma_ros2_utils
+}  // namespace rclcpp_components

--- a/carma_ros2_utils/src/component_manager.cpp
+++ b/carma_ros2_utils/src/component_manager.cpp
@@ -254,7 +254,13 @@ ComponentManager::on_load_node(
         // If the argument has been set then we set the log level for the default logger of this component
         auto log_level_arg_it = std::find(options.arguments().begin(), options.arguments().end(), "--log-level");
 
-        if (log_level_arg_it != options.arguments().end() && log_level_arg_it + 1 != options.arguments().end()) {
+        if (log_level_arg_it == options.arguments().end()) {
+          RCLCPP_DEBUG(get_logger(), "--log-level arg does not appear to be set");
+        
+        } else if (log_level_arg_it + 1 == options.arguments().end()) {
+          RCLCPP_ERROR(get_logger(), "--log-level arg option provided but the log level itself was not");
+        
+        } else {
           // If the log-level has been set on this component then try to set it for the specific logger
           RCUTILS_LOG_SEVERITY sev = RCUTILS_LOG_SEVERITY_WARN;
 
@@ -275,7 +281,11 @@ ComponentManager::on_load_node(
             sev = RCUTILS_LOG_SEVERITY_WARN;
           }
           // Set the log level
-          rcutils_logging_set_logger_level(node_wrappers_[node_id].get_node_base_interface()->get_name(), sev);
+          auto result = rcutils_logging_set_logger_level(node_wrappers_[node_id].get_node_base_interface()->get_name(), sev);
+          
+          if (result != RCUTILS_RET_OK) {
+            RCLCPP_ERROR(get_logger(), "FAILED to set log level when provided with --log-level argument");
+          }
         }
         /////
         // CARMA CHANGE END

--- a/carma_ros2_utils/src/component_manager.cpp
+++ b/carma_ros2_utils/src/component_manager.cpp
@@ -25,11 +25,13 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <boost/algorithm/string.hpp> // CARMA CHANGE
 
 #include "ament_index_cpp/get_resource.hpp"
 #include "class_loader/class_loader.hpp"
 #include "rcpputils/filesystem_helper.hpp"
 #include "rcpputils/split.hpp"
+#include "rcutils/logging.h"
 
 using namespace std::placeholders;
 
@@ -161,6 +163,32 @@ ComponentManager::create_node_options(const std::shared_ptr<LoadNode::Request> r
     remap_rules.push_back("__ns:=" + request->node_namespace);
   }
 
+  /////
+  // CARMA CHANGE START
+  /////
+  // Here we check if the log-level has been set on this component
+  // If it has, then add it to the argument list.
+  for (const auto & a : request->extra_arguments) {
+    const rclcpp::Parameter extra_argument = rclcpp::Parameter::from_parameter_msg(a);
+
+    if (extra_argument.get_name() == "--log-level") {
+
+      RCLCPP_INFO(get_logger(), "Found log-level argument: %s", extra_argument.get_value<std::string>().c_str());
+
+      if (extra_argument.get_type() != rclcpp::ParameterType::PARAMETER_STRING) {
+        throw ComponentManagerException(
+          "Extra component argument 'log-level' must be a string");
+      }
+
+      remap_rules.push_back("--log-level");
+      remap_rules.push_back(extra_argument.get_value<std::string>());
+    }
+  }
+
+  /////
+  // CARMA CHANGE END
+  /////
+
   auto options = rclcpp::NodeOptions()
     .use_global_arguments(false)
     .parameter_overrides(parameters)
@@ -176,28 +204,7 @@ ComponentManager::create_node_options(const std::shared_ptr<LoadNode::Request> r
       options.use_intra_process_comms(extra_argument.get_value<bool>());
     }
 
-    /////
-    // CARMA CHANGE START
-    /////
-    // Here we check if the log-level has been set on this component
-    // If it has, then add it to the argument list.
-    // After the loop completes the list will be reapplied to this component's options
-    if (extra_argument.get_name() == "log-level") {
-      if (extra_argument.get_type() != rclcpp::ParameterType::PARAMETER_STRING) {
-        throw ComponentManagerException(
-          "Extra component argument 'log-level' must be a string");
-      }
-
-      remap_rules.push_back("--log-level");
-      remap_rules.push_back(extra_argument.get_value<std::string>());
-    }
   }
-
-  options.arguments(remap_rules);
-
-  //////
-  // CARMA CHANGE END
-  //////
 
   return options;
 }
@@ -239,6 +246,41 @@ ComponentManager::on_load_node(
 
       try {
         node_wrappers_[node_id] = factory->create_node_instance(options);
+
+        /////
+        // CARMA CHANGE START
+        /////
+        // Here we check if the log-level argument has been set on this component's options
+        // If the argument has been set then we set the log level for the default logger of this component
+        auto log_level_arg_it = std::find(options.arguments().begin(), options.arguments().end(), "--log-level");
+
+        if (log_level_arg_it != options.arguments().end() && log_level_arg_it + 1 != options.arguments().end()) {
+          // If the log-level has been set on this component then try to set it for the specific logger
+          RCUTILS_LOG_SEVERITY sev = RCUTILS_LOG_SEVERITY_WARN;
+
+          std::advance(log_level_arg_it, 1);
+          std::string log_level = *log_level_arg_it;
+          boost::algorithm::to_lower(log_level);
+
+          // Identify the severity with warning as default
+          if (log_level == "debug") {
+            sev = RCUTILS_LOG_SEVERITY_DEBUG;
+          } else if (log_level == "info") {
+            sev = RCUTILS_LOG_SEVERITY_INFO;
+          } else if (log_level == "error") {
+            sev = RCUTILS_LOG_SEVERITY_ERROR;
+          } else if (log_level == "fatal") {
+            sev = RCUTILS_LOG_SEVERITY_FATAL;
+          } else {
+            sev = RCUTILS_LOG_SEVERITY_WARN;
+          }
+          // Set the log level
+          rcutils_logging_set_logger_level(node_wrappers_[node_id].get_node_base_interface()->get_name(), sev);
+        }
+        /////
+        // CARMA CHANGE END
+        /////
+          
       } catch (const std::exception & ex) {
         // In the case that the component constructor throws an exception,
         // rethrow into the following catch block.

--- a/carma_ros2_utils/src/lifecycle_component_wrapper.cpp
+++ b/carma_ros2_utils/src/lifecycle_component_wrapper.cpp
@@ -175,7 +175,7 @@ LifecycleComponentWrapper::create_node_options(const std::shared_ptr<LoadNode::R
       RCLCPP_INFO(get_logger(), "Found log-level argument: %s", extra_argument.get_value<std::string>().c_str());
 
       if (extra_argument.get_type() != rclcpp::ParameterType::PARAMETER_STRING) {
-        throw ComponentManagerException(
+        throw rclcpp_components::ComponentManagerException(
           "Extra component argument 'log-level' must be a string");
       }
 

--- a/carma_ros2_utils/src/lifecycle_component_wrapper.cpp
+++ b/carma_ros2_utils/src/lifecycle_component_wrapper.cpp
@@ -25,6 +25,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <boost/algorithm/string.hpp> // CARMA CHANGE
 
 #include <ament_index_cpp/get_resource.hpp>
 #include <class_loader/class_loader.hpp>

--- a/carma_ros2_utils/src/lifecycle_component_wrapper.cpp
+++ b/carma_ros2_utils/src/lifecycle_component_wrapper.cpp
@@ -279,7 +279,13 @@ LifecycleComponentWrapper::on_load_node(
         // If the argument has been set then we set the log level for the default logger of this component
         auto log_level_arg_it = std::find(options.arguments().begin(), options.arguments().end(), "--log-level");
 
-        if (log_level_arg_it != options.arguments().end() && log_level_arg_it + 1 != options.arguments().end()) {
+        if (log_level_arg_it == options.arguments().end()) {
+          RCLCPP_DEBUG(get_logger(), "--log-level arg does not appear to be set");
+        
+        } else if (log_level_arg_it + 1 == options.arguments().end()) {
+          RCLCPP_ERROR(get_logger(), "--log-level arg option provided but the log level itself was not");
+        
+        } else {
           // If the log-level has been set on this component then try to set it for the specific logger
           RCUTILS_LOG_SEVERITY sev = RCUTILS_LOG_SEVERITY_WARN;
 
@@ -300,7 +306,11 @@ LifecycleComponentWrapper::on_load_node(
             sev = RCUTILS_LOG_SEVERITY_WARN;
           }
           // Set the log level
-          rcutils_logging_set_logger_level(node_wrappers_[node_id].get_node_base_interface()->get_name(), sev);
+          auto result = rcutils_logging_set_logger_level(node_wrappers_[node_id].get_node_base_interface()->get_name(), sev);
+        
+          if (result != RCUTILS_RET_OK) {
+            RCLCPP_ERROR(get_logger(), "FAILED to set log level when provided with --log-level argument");
+          }
         }
         /////
         // CARMA CHANGE END

--- a/carma_ros2_utils/src/lifecycle_component_wrapper.cpp
+++ b/carma_ros2_utils/src/lifecycle_component_wrapper.cpp
@@ -201,28 +201,7 @@ LifecycleComponentWrapper::create_node_options(const std::shared_ptr<LoadNode::R
       }
       options.use_intra_process_comms(extra_argument.get_value<bool>());
     }
-    /////
-    // CARMA CHANGE START
-    /////
-    // Here we check if the log-level has been set on this component
-    // If it has, then add it to the argument list.
-    // After the loop completes the list will be reapplied to this component's options
-    if (extra_argument.get_name() == "log-level") {
-      if (extra_argument.get_type() != rclcpp::ParameterType::PARAMETER_STRING) {
-        throw rclcpp_components::ComponentManagerException(
-          "Extra component argument 'log-level' must be a string");
-      }
-
-      remap_rules.push_back("--log-level");
-      remap_rules.push_back(extra_argument.get_value<std::string>());
-    }
   }
-
-  options.arguments(remap_rules);
-
-  //////
-  // CARMA CHANGE END
-  //////
 
   return options;
 }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR is similar to https://github.com/usdot-fhwa-stol/carma-utils/pull/85 in that id adds the ROS2 component manager into our system as a separate class. While the previous PR was focused on adding a lifecycle wrapper for wrapping Autoware.Auto nodes, the component manager is meant for use with carma nodes as it provides the ability to set the log level for specific components (this appears to be broken in ROS2 Foxy without this change). In this case, logic is added to check for a --log-level argument which is used to set the log level for the logger which will be used for the component. This has the nice property of not causing rcl logs to explode onto the screen when debug is turned on. Since the vast majority of our nodes will be running as components this should effectively bring carma's ros2 logging system up to parity with ros1. This change has also been back ported into the lifecycle_wrapper so it can be used with Autoware.Auto nodes. 
<!--- Describe your changes in detail -->

## Related Issue

This is supporting the ROS2 milestone https://github.com/usdot-fhwa-stol/carma-platform/milestone/4

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Efficient debugging for carma-platform
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Extensive command line testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.