### PR TITLE
Update row_step to match data size when single dimension

### DIFF
--- a/frame_transformer/include/frame_transformer/frame_transformer.hpp
+++ b/frame_transformer/include/frame_transformer/frame_transformer.hpp
@@ -130,10 +130,20 @@ namespace frame_transformer
 
     sensor_msgs::msg::PointCloud2 out_msg;
     out_msg.data.reserve(in_msg->data.size()); // Preallocate points vector
+    
 
     if (!transform(*in_msg, out_msg, config_.target_frame, std_ms(config_.timeout)))
     {
       return;
+    }
+
+    // The following if block is added purely for ensuring consistency with Autoware.Auto (prevent "Malformed PointCloud2" error from ray_ground_filter)
+    // It's a bit out of scope for this node to have this functionality here, 
+    // but the alternative is to modify a 3rd party driver, an Autoware.Auto component, or make a new node just for this.
+    // Therefore, the logic will live here until such a time as a better location presents itself.
+    if (out_msg.height == 1) // 1d point cloud
+    {
+      out_msg.row_step = out_msg.data.size();
     }
 
     output_pub_->publish(out_msg);


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR adds a fix from integration testing to the frame_transformer node. It seems Autoware.Auto checks for the row_step field in the PointCloud2 message which is not populated by default in our ROS1 velodyne driver. This PR adds a quick check to set the field in the message when its being transformed to the appropriate frame. 
<!--- Describe your changes in detail -->

## Related Issue
Supports https://github.com/usdot-fhwa-stol/carma-platform/issues/1557
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Working ROS2 object perception
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested locally on real vehicle data from rosbag
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.