### PR TITLE
Feature/allow lifecycle components in lifecycle wrapper

### DIFF
--- a/carma_ros2_utils/README.md
+++ b/carma_ros2_utils/README.md
@@ -136,7 +136,7 @@ def generate_launch_description():
     ])
 ```
 
-If the user wishes to include a lifecycle component and a non-lifecycle component in the same container (for performance), then they can use the extra arguments ```is_lifecycle_node``` or ```is_carma_lifecycle_node```. These will internally cause an unchecked cast to ```rclcpp_lifecycle::LifecycleNode``` or ```carma_ros2_utils::CarmaLifecycleNode``` respectively. The ```configure()``` and ```activate()``` methods will then be called on this classes. Application of these arguments to classes which to not correspond to these types will lead to undefined behavior. So caution should be taken in their usage. 
+If the user wishes to include a lifecycle component and a non-lifecycle component in the same container (for performance), then they can use the extra arguments ```is_lifecycle_node```. This will internally cause an unchecked cast to ```rclcpp_lifecycle::LifecycleNode```. The ```configure()``` and ```activate()``` methods will then be called on this classes. Application of these arguments to classes which do not directly inherit from this type will lead to undefined behavior. So caution should be taken in their usage.
 
 ```python
 def generate_launch_description():
@@ -153,8 +153,8 @@ def generate_launch_description():
                 plugin='cool_pkg_namespace::MyLifecycleNode',
                 extra_arguments=[
                     {'use_intra_process_comms': True},
-                    # cool_pkg_namespace::MyLifecycleNode extends carma_ros2_utils::CarmaLifecycleNode and does not overload configure() or activate() so it is safe to make this call here.
-                    {'is_carma_lifecycle_node' : True } 
+                    # cool_pkg_namespace::MyLifecycleNode extends rclcpp_lifecycle::LifecycleNode and does not overload configure() or activate() so it is safe to make this call here.
+                    {'is_lifecycle_node' : True } 
                 ],
             ),
         ]

--- a/carma_ros2_utils/README.md
+++ b/carma_ros2_utils/README.md
@@ -135,3 +135,32 @@ def generate_launch_description():
         lifecycle_container,
     ])
 ```
+
+If the user wishes to include a lifecycle component and a non-lifecycle component in the same container (for performance), then they can use the extra arguments ```is_lifecycle_node``` or ```is_carma_lifecycle_node```. These will internally cause an unchecked cast to ```rclcpp_lifecycle::LifecycleNode``` or ```carma_ros2_utils::CarmaLifecycleNode``` respectively. The ```configure()``` and ```activate()``` methods will then be called on this classes. Application of these arguments to classes which to not correspond to these types will lead to undefined behavior. So caution should be taken in their usage. 
+
+```python
+def generate_launch_description():
+  
+    lifecycle_container = ComposableNodeContainer( 
+        package='rclcpp_components',
+        name='lifecycle_component_wrapper', 
+        executable='lifecycle_component_wrapper_mt', 
+        namespace="/",
+        composable_node_descriptions=[
+            ComposableNode( 
+                package='cool_pkg',
+                name='my_lifecycle_node',
+                plugin='cool_pkg_namespace::MyLifecycleNode',
+                extra_arguments=[
+                    {'use_intra_process_comms': True},
+                    # cool_pkg_namespace::MyLifecycleNode extends carma_ros2_utils::CarmaLifecycleNode and does not overload configure() or activate() so it is safe to make this call here.
+                    {'is_carma_lifecycle_node' : True } 
+                ],
+            ),
+        ]
+    )
+
+    return LaunchDescription([
+        lifecycle_container,
+    ])
+```

--- a/carma_ros2_utils/src/lifecycle_component_wrapper.cpp
+++ b/carma_ros2_utils/src/lifecycle_component_wrapper.cpp
@@ -327,6 +327,16 @@ LifecycleComponentWrapper::on_load_node(
         throw rclcpp_components::ComponentManagerException("Component constructor threw an exception");
       }
 
+      bool is_lifecycle_node = dynamic_cast<rclcpp_lifecycle::LifecycleNode*>(node_wrappers_[node_id].get_node_instance()->get()) != nullptr;
+
+      if (is_lifecycle_node) {
+        RCLCPP_INFO_STEAM(get_logger(), "A lifecycle component has been loaded by the LifecycleComponentWrapper. Attempting to move it to the ACTIVE state.");
+        std::shared_ptr<rclcpp_lifecycle::LifecycleNode> lifecycle_node = std::dynamic_pointer_cast<rclcpp_lifecycle::LifecycleNode>(node_wrappers_[node_id].get_node_instance());
+        lifecycle_node->configure();
+        lifecycle_node->activate();
+      }
+      
+
       auto node = node_wrappers_[node_id].get_node_base_interface();
       if (auto exec = executor_.lock()) {
         exec->add_node(node, true);

--- a/carma_ros2_utils/src/lifecycle_component_wrapper.cpp
+++ b/carma_ros2_utils/src/lifecycle_component_wrapper.cpp
@@ -343,27 +343,18 @@ LifecycleComponentWrapper::on_load_node(
             throw rclcpp_components::ComponentManagerException(
                     "Extra component argument 'is_lifecycle_node' must be a boolean");
           }
-        
-          RCLCPP_INFO_STEAM(get_logger(), "A lifecycle component has been loaded by the LifecycleComponentWrapper. Attempting to move it to the ACTIVE state.");
-          std::shared_ptr<rclcpp_lifecycle::LifecycleNode> lifecycle_node = std::static_pointer_cast<rclcpp_lifecycle::LifecycleNode>(node_wrappers_[node_id].get_node_instance());
-          lifecycle_node->configure();
-          lifecycle_node->activate();
 
-        }
-
-        if (extra_argument.get_name() == "is_carma_lifecycle_node") {
-          
-          if (extra_argument.get_type() != rclcpp::ParameterType::PARAMETER_BOOL) {
-            throw rclcpp_components::ComponentManagerException(
-                    "Extra component argument 'is_lifecycle_node' must be a boolean");
+          if (extra_argument.as_bool()) {
+            
+            RCLCPP_INFO_STREAM(get_logger(), "A lifecycle component has been loaded by the LifecycleComponentWrapper. Attempting to move it to the ACTIVE state.");
+            
+            std::shared_ptr<rclcpp_lifecycle::LifecycleNode> lifecycle_node = std::static_pointer_cast<rclcpp_lifecycle::LifecycleNode>(node_wrappers_[node_id].get_node_instance());
+            lifecycle_node->configure();
+            lifecycle_node->activate();
           }
-        
-          RCLCPP_INFO_STEAM(get_logger(), "A carma lifecycle component has been loaded by the LifecycleComponentWrapper. Attempting to move it to the ACTIVE state.");
-          std::shared_ptr<carma_ros2_utils::CarmaLifecycleNode> lifecycle_node = std::static_pointer_cast<carma_ros2_utils::CarmaLifecycleNode>(node_wrappers_[node_id].get_node_instance());
-          lifecycle_node->configure();
-          lifecycle_node->activate();
 
         }
+
       }
 
       /////

--- a/carma_ros2_utils/src/lifecycle_component_wrapper.cpp
+++ b/carma_ros2_utils/src/lifecycle_component_wrapper.cpp
@@ -327,15 +327,48 @@ LifecycleComponentWrapper::on_load_node(
         throw rclcpp_components::ComponentManagerException("Component constructor threw an exception");
       }
 
-      bool is_lifecycle_node = dynamic_cast<rclcpp_lifecycle::LifecycleNode*>(node_wrappers_[node_id].get_node_instance()->get()) != nullptr;
+      /////
+      // CARMA CHANGE START
+      /////
 
-      if (is_lifecycle_node) {
-        RCLCPP_INFO_STEAM(get_logger(), "A lifecycle component has been loaded by the LifecycleComponentWrapper. Attempting to move it to the ACTIVE state.");
-        std::shared_ptr<rclcpp_lifecycle::LifecycleNode> lifecycle_node = std::dynamic_pointer_cast<rclcpp_lifecycle::LifecycleNode>(node_wrappers_[node_id].get_node_instance());
-        lifecycle_node->configure();
-        lifecycle_node->activate();
+
+      // Check if the loaded node is a lifecycle node and if it is then updates its activation
+      for (const auto & a : request->extra_arguments) {
+        
+        const rclcpp::Parameter extra_argument = rclcpp::Parameter::from_parameter_msg(a);
+        
+        if (extra_argument.get_name() == "is_lifecycle_node") {
+          
+          if (extra_argument.get_type() != rclcpp::ParameterType::PARAMETER_BOOL) {
+            throw rclcpp_components::ComponentManagerException(
+                    "Extra component argument 'is_lifecycle_node' must be a boolean");
+          }
+        
+          RCLCPP_INFO_STEAM(get_logger(), "A lifecycle component has been loaded by the LifecycleComponentWrapper. Attempting to move it to the ACTIVE state.");
+          std::shared_ptr<rclcpp_lifecycle::LifecycleNode> lifecycle_node = std::static_pointer_cast<rclcpp_lifecycle::LifecycleNode>(node_wrappers_[node_id].get_node_instance());
+          lifecycle_node->configure();
+          lifecycle_node->activate();
+
+        }
+
+        if (extra_argument.get_name() == "is_carma_lifecycle_node") {
+          
+          if (extra_argument.get_type() != rclcpp::ParameterType::PARAMETER_BOOL) {
+            throw rclcpp_components::ComponentManagerException(
+                    "Extra component argument 'is_lifecycle_node' must be a boolean");
+          }
+        
+          RCLCPP_INFO_STEAM(get_logger(), "A carma lifecycle component has been loaded by the LifecycleComponentWrapper. Attempting to move it to the ACTIVE state.");
+          std::shared_ptr<carma_ros2_utils::CarmaLifecycleNode> lifecycle_node = std::static_pointer_cast<carma_ros2_utils::CarmaLifecycleNode>(node_wrappers_[node_id].get_node_instance());
+          lifecycle_node->configure();
+          lifecycle_node->activate();
+
+        }
       }
-      
+
+      /////
+      // CARMA CHANGE END
+      /////
 
       auto node = node_wrappers_[node_id].get_node_base_interface();
       if (auto exec = executor_.lock()) {


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

This PR modifies the lifecycle component wrapper to have an extra argument ```is_lifecycle_node``` which can be set on nodes which are already lifecycle components. When these components are loaded in activate() they will be cast to LifecycleNodes and activate() and configure() will be called on them. This ensures that they reflect the current state of the container. The readme has been updated to reflect this change as well as the risks involved with its usage. 
<!--- Describe your changes in detail -->

## Related Issue
Supports https://github.com/usdot-fhwa-stol/carma-platform/issues/1557
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
The primary motivation for this change is that the Autoware.Auto nodes currently require some custom lifecycle nodes interspersed in their data stream which reduces efficiency from components if these cannot live in the same container. This argument allows for them to do this while still supporting the intra process communications. 
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local integration testing
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.