### PR TITLE
Properly publish the system alert on a primary state error

### DIFF
--- a/carma_ros2_utils/include/carma_ros2_utils/carma_lifecycle_node.hpp
+++ b/carma_ros2_utils/include/carma_ros2_utils/carma_lifecycle_node.hpp
@@ -163,7 +163,7 @@ namespace carma_ros2_utils
    * \brief Callback triggered when transitioning from any state to ErrorProcessing due to the error signal.
    *        This method should be overriden to add any exception handling logic.
    * 
-   *        NOTE: CarmaLifecycleNode will automatically publish a SystemAlert before this is triggered. 
+   *        NOTE: CarmaLifecycleNode will automatically publish a FATAL SystemAlert before this is triggered. 
    * 
    * \param state The previous state 
    * 

--- a/carma_ros2_utils/src/carma_lifecycle_node.cpp
+++ b/carma_ros2_utils/src/carma_lifecycle_node.cpp
@@ -175,7 +175,7 @@ namespace carma_ros2_utils
     pub_msg.source_node = get_node_base_interface()->get_fully_qualified_name(); // The the source name for the message
 
     if (!system_alert_pub_->is_activated()) {
-      RCLCPP_ERROR_STREAM(get_logger(), "Sending SystemAlert likely failed as publisher is deactivated.");
+      RCLCPP_WARN_STREAM(get_logger(), "Sending SystemAlert likely failed as publisher is deactivated.");
     }
 
     system_alert_pub_->publish(msg); 

--- a/carma_ros2_utils/src/carma_lifecycle_node.cpp
+++ b/carma_ros2_utils/src/carma_lifecycle_node.cpp
@@ -174,6 +174,10 @@ namespace carma_ros2_utils
 
     pub_msg.source_node = get_node_base_interface()->get_fully_qualified_name(); // The the source name for the message
 
+    if (!system_alert_pub_->is_activated()) {
+      RCLCPP_ERROR_STREAM(get_logger(), "Sending SystemAlert likely failed as publisher is deactivated.");
+    }
+
     system_alert_pub_->publish(msg); 
   }
 

--- a/carma_ros2_utils/src/carma_lifecycle_node.cpp
+++ b/carma_ros2_utils/src/carma_lifecycle_node.cpp
@@ -178,7 +178,7 @@ namespace carma_ros2_utils
       RCLCPP_WARN_STREAM(get_logger(), "Sending SystemAlert likely failed as publisher is deactivated.");
     }
 
-    system_alert_pub_->publish(msg); 
+    system_alert_pub_->publish(pub_msg); 
   }
 
   void CarmaLifecycleNode::send_error_alert_msg_for_string(const std::string &alert_string)

--- a/carma_ros2_utils/src/carma_lifecycle_node.cpp
+++ b/carma_ros2_utils/src/carma_lifecycle_node.cpp
@@ -125,18 +125,19 @@ namespace carma_ros2_utils
       error_string = "Exception occurred during lifecycle state transitions. Look for 'Caught exception' in the logs for details.";
       RCLCPP_ERROR_STREAM(get_logger(), error_string);
 
-      try
-      {
+    }
 
-        send_error_alert_msg_for_string(error_string);
-        RCLCPP_ERROR_STREAM(get_logger(), "Sent on_error system alert");
-      }
-      catch (const std::exception &e)
-      {
+    try
+    {
 
-        RCLCPP_ERROR_STREAM(get_logger(), "Failed to send on_error system alert. Forcing shutdown.");
-        return CallbackReturn::FAILURE;
-      }
+      send_error_alert_msg_for_string(error_string);
+      RCLCPP_ERROR_STREAM(get_logger(), "Sent on_error system alert");
+    }
+    catch (const std::exception &e)
+    {
+
+      RCLCPP_ERROR_STREAM(get_logger(), "Failed to send on_error system alert. Forcing shutdown.");
+      return CallbackReturn::FAILURE;
     }
 
     // Call the user error handling before clean up of the publishers to allow them to publish if needed


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR moves the system alert publication for uncaught exceptions below the primary vs transitory state check. This was the intended functionality, but it might have been a typo when implementing the primary state handling. 
<!--- Describe your changes in detail -->

## Related Issue
Resolves https://github.com/usdot-fhwa-stol/carma-platform/issues/1640
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Reliable error handling in carma-platform
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Testing on ford fusion
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.