### PR TITLE
Fix clock initialization in TestTimerFactory

### DIFF
--- a/carma_ros2_utils/src/timers/testing/TestTimerFactory.cpp
+++ b/carma_ros2_utils/src/timers/testing/TestTimerFactory.cpp
@@ -25,11 +25,19 @@ TestTimerFactory::~TestTimerFactory(){}
 
 void TestTimerFactory::setNow(const rclcpp::Time& current_time)
 {
+  if (!clock_) // lazy initialization of clock
+  {
+    clock_ = std::make_shared<TestClock>();
+  }
   clock_->setNow(current_time);
 }
 
 rclcpp::Time TestTimerFactory::now()
 {
+  if (!clock_) // lazy initialization of clock
+  {
+    clock_ = std::make_shared<TestClock>();
+  }
   return clock_->now();
 }
 
@@ -37,7 +45,7 @@ std::unique_ptr<Timer> TestTimerFactory::buildTimer(uint32_t id, rclcpp::Duratio
                                                     std::function<void()> callback, bool oneshot,
                                                     bool autostart)
 {
-  if (!clock_)
+  if (!clock_) // lazy initialization of clock
   {
     clock_ = std::make_shared<TestClock>();
   }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Resolves https://github.com/usdot-fhwa-stol/carma-platform/issues/1893 
Applies the same lazy initialization pattern for initializing the clock to all functions which use it.
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/1893
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Reliable unit tests
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
In current port of platooning strategic plugin
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.