### PR TITLE
#145 Declare on_... functions as final

### DIFF
--- a/carma_ros2_utils/include/carma_ros2_utils/carma_lifecycle_node.hpp
+++ b/carma_ros2_utils/include/carma_ros2_utils/carma_lifecycle_node.hpp
@@ -104,12 +104,12 @@ namespace carma_ros2_utils
    * NOTE: These methods are NOT meant to be used by extending classes. Instead the corresponding handle_<method> methods should be used 
    *       to ensure the full CARMALifecycleNode functionality is employed.
    */
-    carma_ros2_utils::CallbackReturn on_configure(const rclcpp_lifecycle::State &prev_state) override;
-    carma_ros2_utils::CallbackReturn on_activate(const rclcpp_lifecycle::State &prev_state) override;
-    carma_ros2_utils::CallbackReturn on_deactivate(const rclcpp_lifecycle::State &prev_state) override;
-    carma_ros2_utils::CallbackReturn on_cleanup(const rclcpp_lifecycle::State &prev_state) override;
-    carma_ros2_utils::CallbackReturn on_error(const rclcpp_lifecycle::State &prev_state) override;
-    carma_ros2_utils::CallbackReturn on_shutdown(const rclcpp_lifecycle::State &prev_state) override;
+    carma_ros2_utils::CallbackReturn on_configure(const rclcpp_lifecycle::State &prev_state) override final;
+    carma_ros2_utils::CallbackReturn on_activate(const rclcpp_lifecycle::State &prev_state) override final;
+    carma_ros2_utils::CallbackReturn on_deactivate(const rclcpp_lifecycle::State &prev_state) override final;
+    carma_ros2_utils::CallbackReturn on_cleanup(const rclcpp_lifecycle::State &prev_state) override final;
+    carma_ros2_utils::CallbackReturn on_error(const rclcpp_lifecycle::State &prev_state) override final;
+    carma_ros2_utils::CallbackReturn on_shutdown(const rclcpp_lifecycle::State &prev_state) override final;
 
     /**
    * \brief Callback triggered when transitioning from UNCONFIGURED to INACTIVE due to the configure signal.


### PR DESCRIPTION
# PR Details
## Description

This PR changes the `on_...` functions in the `CarmaLifecycleNode` class (which are overrides of the `on_...` functions from ROS's `LifecycleNode`) to be declared as `final`. This will prevent deriving classes from overriding these functions, attempting to do so will cause compile-time errors. We want deriving classes to override `handle_on_...` functions instead, but there is no mechanism to enforce this. This PR adds an enforcement mechanism.

## Related GitHub Issue

Closes #145 

## Related Jira Key

N/A

## Motivation and Context

See description above.

## How Has This Been Tested?

The `carma_ros2_utils` package compiles with these changes. Any errors would have presented at compile time.

## Types of changes

- [x] New feature (non-breaking change that adds functionality)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] All new and existing tests passed.
