### PR TITLE
Fix issue when querying sensor position

### DIFF
--- a/sensorlib/src/CarlaCDASimAPI.py
+++ b/sensorlib/src/CarlaCDASimAPI.py
@@ -109,6 +109,7 @@ class CarlaCDASimAPI:
         sensor_bp = self.__generate_lidar_bp(blueprint_library, carla_sensor_config)
         parent_actor = CarlaUtils.get_actor(self.__carla_world, parent_actor_id)
         carla_sensor = self.__carla_world.spawn_actor(sensor_bp, sensor_transform, attach_to=parent_actor)
+        self.__carla_world.wait_for_tick()
 
         # Build internal objects
         sensor = CarlaSensorBuilder.build_sensor(carla_sensor)


### PR DESCRIPTION
# PR Details
## Description

This PR resolves a timing issue when interacting with CARLA. The `CarlaCDASimAPI` class did not wait for CARLA to update the world before querying the newly-created sensor's position, resulting in the wrong value. The class now waits for CARLA to tick the world state.

## Related GitHub Issue

Closes #163 

## Related Jira Key

Closes [CDAR-474](https://usdot-carma.atlassian.net/browse/CDAR-474)

## Motivation and Context

If a client queries CARLA about a new actor's position before CARLA has time to update the world state, the returned position will be the origin (0, 0, 0). This will break any distance-based computations.

## How Has This Been Tested?

Manually confirmed proposed change fixed issue.

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.


[CDAR-474]: https://usdot-carma.atlassian.net/browse/CDAR-474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ