### PR TITLE
[sensorlib] Clear `SemanticLidarSensor` detections list when there are no detected objects

### DIFF
--- a/sensorlib/src/sensor/SemanticLidarSensor.py
+++ b/sensorlib/src/sensor/SemanticLidarSensor.py
@@ -86,14 +86,16 @@ class SemanticLidarSensor(SimulatedSensor):
 
         #check if there's object in range
         if not detected_objects:
-            return None
+            self.__detected_objects.clear()
+            return []
 
         # Prefilter
         detected_objects, object_ranges = self.prefilter(detected_objects)
 
         #check if there's object in range
         if not detected_objects:
-            return None
+            self.__detected_objects.clear()
+            return []
 
         # Get LIDAR hitpoints with Actor ID associations
         timestamp, hitpoints = self.__data_collector.get_carla_lidar_hitpoints()


### PR DESCRIPTION
# PR Details
## Description

This PR fixes the issue where detected objects are retained after leaving a sensor's field of view. The `SemanticLidarSensor` now clears it detected object list when it does not detect any objects in the environment. The `compute_detected_objects()` function now always returns a (possibly empty) list instead of sometimes returning None. This makes for a more consistent interface.

## Related GitHub Issue

Closes #167 

## Related Jira Key

Closes [CDAR-447](https://usdot-carma.atlassian.net/browse/CDAR-477)

## Motivation and Context

The `SemanticLidarSensor` class was retaining detected objects after they leave the field of view, causing incorrect detection reports.

## How Has This Been Tested?

Manually tested to ensure changes resolved issue.

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[CDAR-447]: https://usdot-carma.atlassian.net/browse/CDAR-447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ