### PR TITLE
#190 Flip y-axis value in SemanticLidarSensor

### DIFF
--- a/sensorlib/src/collector/SensorDataCollector.py
+++ b/sensorlib/src/collector/SensorDataCollector.py
@@ -72,7 +72,7 @@ class SensorDataCollector:
         # Add data to the current collection
         if (len(semantic_sensor_data.raw_data) == 0):
             return None
-        
+
         self.__collect_raw_point_data(self.__data[0], semantic_sensor_data)
 
     def __collect_raw_point_data(self, grouped_data, raw_sensor_data):
@@ -92,9 +92,15 @@ class SensorDataCollector:
             # https://github.com/carla-simulator/carla/issues/3191
             if (detection.object_idx == 0):
                 continue
-            
+
             point = CarlaUtils.vector3d_to_numpy(detection.point)
-           
+
+            # CARLA 0.9.10 has a bug where the y-axis value is negated.
+            # This was resolved in a later release, but CARMA currently
+            # uses 0.9.10. Remove this fix when CARMA upgrades to a
+            # newer CARLA version.
+            point[1] *= -1
+
             if detection.object_idx not in grouped_data:
                 grouped_data[detection.object_idx] = [point]
             else:


### PR DESCRIPTION
# PR Details
## Description

This PR patches an issue in CARLA 0.9.10 where the y-axis value for objects is flipped. Since CARMA uses CARLA 0.9.10, `sensorlib` flips the y-axis value to compensate for the error.

## Related GitHub Issue

Closes #190 
Replaces the (reverted) patch applied in usdot-fhwa-stol/carma-carla-integration#47

## Related Jira Key

Closes [CDAR-526](https://usdot-carma.atlassian.net/browse/CDAR-526)

## Motivation and Context

Instead of applying _ad-hoc_ patches throughout CARMA, we decided it would be better to have only software the interfaces directly with CARMA be aware of the bug. This reduces the overhead when we can remove the patch. Instead of changing several places, we only need to change one (or a few).

## How Has This Been Tested?

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)
- [x] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[CDAR-526]: https://usdot-carma.atlassian.net/browse/CDAR-526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ