### PR TITLE
Fix Y value for objects coming from CARLA

### DIFF
--- a/sensorlib/src/collector/SensorDataCollector.py
+++ b/sensorlib/src/collector/SensorDataCollector.py
@@ -95,12 +95,6 @@ class SensorDataCollector:
 
             point = CarlaUtils.vector3d_to_numpy(detection.point)
 
-            # CARLA 0.9.10 has a bug where the y-axis value is negated.
-            # This was resolved in a later release, but CARMA currently
-            # uses 0.9.10. Remove this fix when CARMA upgrades to a
-            # newer CARLA version.
-            point[1] *= -1
-
             if detection.object_idx not in grouped_data:
                 grouped_data[detection.object_idx] = [point]
             else:

--- a/sensorlib/src/sensor/SemanticLidarSensor.py
+++ b/sensorlib/src/sensor/SemanticLidarSensor.py
@@ -480,9 +480,17 @@ class SemanticLidarSensor(SimulatedSensor):
 
         # If enabled, convert coordinates to sensor-centric frame
         new_position = obj.position
+
         if self.__simulated_sensor_config["use_sensor_centric_frame"]:
             sensor_location = self.__sensor.carla_sensor.get_location()
             new_position = np.subtract(obj.position, np.array([sensor_location.x, sensor_location.y, sensor_location.z]))
+
+        # CARLA 0.9.10 has a bug where the y-axis value is negated.
+        # This was resolved in a later release, but CARMA currently
+        # uses 0.9.10. Remove this fix when CARMA upgrades to a
+        # newer CARLA version.
+
+        new_position[1] *= -1.0
 
         return replace(obj,
                        timestamp=timestamp,


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Previously we discovered that the Y value of CARLA objects are wrong. 
We incorrectly assumed that the hitpoints report absolute values. hitpoints from sensor is probably correct as they are in their own frame (small values, smaller the distance).
However, the object's locations and sensor's locations all report in negative Y value. Therefore, it is the best to do all the calculations as is and only change the Y value before reporting the detected objects to the caller of the sensor.

NOTE: currently not finished testing yet
<!--- Describe your changes in detail -->
Fix for PR: https://github.com/usdot-fhwa-stol/carma-utils/pull/191

## Related GitHub Issue
Closes: https://github.com/usdot-fhwa-stol/carma-utils/issues/190
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
Closes https://usdot-carma.atlassian.net/browse/CDAR-526

<!-- e.g. CAR-123 -->

## Motivation and Context
See above
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
CDASIM integration tested, platform reports y values in positive
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
