### PR TITLE
Fix compiler errors that were not caught by GCC

### DIFF
--- a/carma_ros2_utils/.clang-tidy
+++ b/carma_ros2_utils/.clang-tidy
@@ -1,0 +1,14 @@
+---
+Checks: >-
+  bugprone-*,
+  cert-*,
+  clang-analyzer-*,
+  concurrency-*,
+  cppcoreguidelines-*,
+  misc-*,
+  modernize-*,
+  performance-*,
+  portability-*,
+  readability-*
+FormatStyle: "file"
+HeaderFilterRegex: ".*"

--- a/carma_ros2_utils/CMakeLists.txt
+++ b/carma_ros2_utils/CMakeLists.txt
@@ -9,6 +9,8 @@ find_package(ament_cmake_auto REQUIRED)
 find_package(ament_cmake_python REQUIRED)
 ament_auto_find_build_dependencies()
 
+# The generated compilation database is helpful with code completion in IDEs and linting tools
+set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 
 # Includes
 include_directories(

--- a/carma_ros2_utils/include/carma_ros2_utils/internal/carma_lifecycle_node.tpp
+++ b/carma_ros2_utils/include/carma_ros2_utils/internal/carma_lifecycle_node.tpp
@@ -22,13 +22,10 @@ namespace carma_ros2_utils
   template <
       typename MessageT,
       typename CallbackT,
-      typename AllocatorT = std::allocator<void>,
-      typename CallbackMessageT =
-          typename rclcpp::subscription_traits::has_message_type<CallbackT>::type,
-      typename SubscriptionT = rclcpp::Subscription<MessageT, AllocatorT>,
-      typename MessageMemoryStrategyT = rclcpp::message_memory_strategy::MessageMemoryStrategy<
-          CallbackMessageT,
-          AllocatorT>>
+      typename AllocatorT,
+      typename CallbackMessageT,
+      typename SubscriptionT,
+      typename MessageMemoryStrategyT>
   std::shared_ptr<SubscriptionT>
   CarmaLifecycleNode::create_subscription(
       const std::string &topic_name,
@@ -41,7 +38,7 @@ namespace carma_ros2_utils
     return rclcpp_lifecycle::LifecycleNode::create_subscription<MessageT>(
         topic_name, qos,
         // The move capture "callback = std::move(callback)" is specifically needed
-        // here because of the unique_ptr<> in the callback arguments 
+        // here because of the unique_ptr<> in the callback arguments
         // when the callback is provided with std::bind
         // the returned functor degrades to be move-constructable not copy-constructable
         // https://www.cplusplus.com/reference/functional/bind/
@@ -54,7 +51,7 @@ namespace carma_ros2_utils
           }
           catch(const std::exception &e)
           {
-            handle_primary_state_exception(e); 
+            handle_primary_state_exception(e);
 
           } catch (...) {
             handle_primary_state_exception();
@@ -63,7 +60,7 @@ namespace carma_ros2_utils
         options, msg_mem_strat);
   }
 
-  template <typename MessageT, typename AllocatorT = std::allocator<void>>
+  template <typename MessageT, typename AllocatorT>
   std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<MessageT, AllocatorT>>
   CarmaLifecycleNode::create_publisher(
       const std::string &topic_name,
@@ -75,7 +72,7 @@ namespace carma_ros2_utils
     return pub;
   }
 
-  template <typename DurationRepT = int64_t, typename DurationT = std::milli, typename CallbackT>
+  template <typename DurationRepT, typename DurationT, typename CallbackT>
   std::shared_ptr<rclcpp::TimerBase>
   CarmaLifecycleNode::create_wall_timer(
       std::chrono::duration<DurationRepT, DurationT> period,
@@ -92,7 +89,7 @@ namespace carma_ros2_utils
       }
       catch(const std::exception &e)
       {
-        handle_primary_state_exception(e); 
+        handle_primary_state_exception(e);
 
       } catch (...) {
         handle_primary_state_exception();
@@ -154,8 +151,8 @@ namespace carma_ros2_utils
           }
           catch(const std::exception &e)
           {
-            handle_primary_state_exception(e); 
-            
+            handle_primary_state_exception(e);
+
           } catch (...) {
             handle_primary_state_exception();
           }
@@ -166,7 +163,7 @@ namespace carma_ros2_utils
   template <class ServiceT>
   typename rclcpp::Client<ServiceT>::SharedPtr
   CarmaLifecycleNode::create_client (
-    const std::string service_name, 
+    const std::string service_name,
     const rmw_qos_profile_t & qos_profile,
     rclcpp::CallbackGroup::SharedPtr group
   )
@@ -174,7 +171,7 @@ namespace carma_ros2_utils
     // nullptr is the default argument for group
     // when nullptr is provided use the class level service group
     // this is needed instead of a default argument because you cannot change default arguments in overrides
-    if (group == nullptr) { 
+    if (group == nullptr) {
       group = this->service_callback_group_;
     }
 
@@ -188,9 +185,9 @@ namespace carma_ros2_utils
    * \brief Internal helper method to compare a ParameterType with a template argument
    * \tparam T The compiled type to compare
    * \param type The ROS ParameterType to compare
-   * 
+   *
    * \return true if the ParameterType matches the template argument. False otherwise.
-   */ 
+   */
   template<typename T>
   bool same_param_type(const rclcpp::ParameterType& type)
   {
@@ -219,7 +216,7 @@ namespace carma_ros2_utils
 
       case rclcpp::ParameterType::PARAMETER_STRING_ARRAY:
         return std::is_same_v<T, std::vector<std::string>>;
-    
+
       default:
         return false;
     }
@@ -227,18 +224,18 @@ namespace carma_ros2_utils
 
   template<typename T>
   boost::optional<std::string> CarmaLifecycleNode::update_params(const std::unordered_map<std::string, std::reference_wrapper<T>>& update_targets,
-                   const std::vector< rclcpp::Parameter > & new_params) 
+                   const std::vector< rclcpp::Parameter > & new_params)
   {
     std::unordered_map<std::string, std::function<T(T)>> func_map;
     func_map.reserve(update_targets.size());
 
     // Create setter methods for all reference parameters
     for (auto& pair : update_targets) {
-      func_map[pair.first] = [&pair](T t) { 
-        
+      func_map[pair.first] = [&pair](T t) {
+
         T temp = pair.second;
         pair.second.get() = t; // Assign to the reference
-        return temp; 
+        return temp;
 
       };
     }
@@ -261,7 +258,7 @@ namespace carma_ros2_utils
 
         std::string error = "Cannot update parameter " + param.get_name() + " it has mismatched type " + typeid(T).name() + " and " + param.get_type_name();
         RCLCPP_ERROR_STREAM(get_logger(), error);
-      
+
         return error;
       }
 

--- a/carma_ros2_utils/package.xml
+++ b/carma_ros2_utils/package.xml
@@ -35,6 +35,7 @@
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>carma_ament_cmake_clang_tidy</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>

--- a/carma_ros2_utils/package.xml
+++ b/carma_ros2_utils/package.xml
@@ -35,7 +35,7 @@
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
-  <test_depend>carma_ament_cmake_clang_tidy</test_depend>
+  <test_depend>ament_cmake_clang_tidy</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>

--- a/carma_ros2_utils/test/CMakeLists.txt
+++ b/carma_ros2_utils/test/CMakeLists.txt
@@ -4,7 +4,11 @@ find_package(ros2_lifecycle_manager REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(ament_cmake_pytest REQUIRED)
-find_package(launch_testing_ament_cmake REQUIRED) 
+find_package(launch_testing_ament_cmake REQUIRED)
+find_package(carma_ament_cmake_clang_tidy REQUIRED)
+
+set(carma_ament_cmake_clang_tidy_CONFIG_FILE ${PROJECT_SOURCE_DIR}/.clang-tidy)
+carma_ament_clang_tidy(${PROJECT_BINARY_DIR})
 
 set(dependencies ${dependencies} ros2_lifecycle_manager std_srvs)
 
@@ -104,10 +108,10 @@ install(
   # EXPORT should not be needed for unit tests
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib/${PROJECT_NAME}
-  RUNTIME DESTINATION lib/${PROJECT_NAME} # In Ament, Executables are installed to lib/${PROJECT_NAME} not bin 
+  RUNTIME DESTINATION lib/${PROJECT_NAME} # In Ament, Executables are installed to lib/${PROJECT_NAME} not bin
   INCLUDES DESTINATION include
 )
 
-# This is a bit of a hack to allow for rclcpp_component registration in this subdirectory 
+# This is a bit of a hack to allow for rclcpp_component registration in this subdirectory
 # Based off sloretz's answer from ROS Answers here https://answers.ros.org/question/361289/ros2-components-registration-from-subdirectory-cmakelists-file/
 #set(AMENT_EXTENSIONS_ament_package ${AMENT_EXTENSIONS_ament_package} PARENT_SCOPE)

--- a/carma_ros2_utils/test/CMakeLists.txt
+++ b/carma_ros2_utils/test/CMakeLists.txt
@@ -5,10 +5,10 @@ find_package(std_srvs REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(ament_cmake_pytest REQUIRED)
 find_package(launch_testing_ament_cmake REQUIRED)
-find_package(carma_ament_cmake_clang_tidy REQUIRED)
+find_package(ament_cmake_clang_tidy REQUIRED)
 
-set(carma_ament_cmake_clang_tidy_CONFIG_FILE ${PROJECT_SOURCE_DIR}/.clang-tidy)
-carma_ament_clang_tidy(${PROJECT_BINARY_DIR})
+set(ament_cmake_clang_tidy_CONFIG_FILE ${PROJECT_SOURCE_DIR}/.clang-tidy)
+ament_clang_tidy(${PROJECT_BINARY_DIR})
 
 set(dependencies ${dependencies} ros2_lifecycle_manager std_srvs)
 


### PR DESCRIPTION
# PR Details
## Description

This PR adds a Clang-Tidy configuration to help improve our software quality with static analysis. When running the tool, clang-tidy reported a compiler error that was not caught by the GCC version we are using. The GCC version we currently use has a bug that was patched in newer versions. Clang (which clang-tidy uses internally) does not have this bug.

## Related GitHub Issue

Closes #205 

## Related Jira Key

Closes [CDAR-674](https://usdot-carma.atlassian.net/browse/CDAR-674)

## Motivation and Context

Compilation error

## How Has This Been Tested?

N/A, compiler errors

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.


[CDAR-674]: https://usdot-carma.atlassian.net/browse/CDAR-674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ