### PR TITLE
Negate y value for created sensors to account for inverted y-axis of carla

### DIFF
--- a/sensorlib/src/CarlaCDASimAdapter.py
+++ b/sensorlib/src/CarlaCDASimAdapter.py
@@ -8,7 +8,7 @@
 
 import argparse
 import threading
-
+import logging
 from xmlrpc.server import SimpleXMLRPCServer
 import sys
 sys.path.append('../')
@@ -63,8 +63,11 @@ class CarlaCDASimAdapter:
     def __create_simulated_semantic_lidar_sensor(self,
                                                  infrastructure_id, sensor_id,
                                                  sensor_position, sensor_rotation):
-
-
+        logging.info("Received request to create sensor at " + sensor_position)
+        # CARLA 0.9.10 has a bug where the y-axis value is negated.
+        # To correct for this we are negating the request sensor location y
+        # position
+        logging.info("Updated sensor position to " + sensor_position)
         simulated_sensor = self.__api.create_simulated_semantic_lidar_sensor(self.sensor_config["simulated_sensor"],
                                                                              self.sensor_config["lidar_sensor"],
                                                                              self.noise_model_config,
@@ -126,6 +129,13 @@ if __name__ == "__main__":
         default=0.1,
         type=float,
         help="Time interval between detection reporting. (default: 0.1)")
+    arg_parser.add_argument(
+        "--log-level",
+        default="INFO",
+        type=str,
+        help="Log Level for service (default: INFO)")
+    level = logging.getLevelName(args.log_level)
+    logging.getLogger().setLevel(level)
     args = arg_parser.parse_args()
     sensor_api = CarlaCDASimAPI.build_from_host_spec(args.carla_host, args.carla_port)
     sensor_data_service = CarlaCDASimAdapter(sensor_api)

--- a/sensorlib/src/CarlaCDASimAdapter.py
+++ b/sensorlib/src/CarlaCDASimAdapter.py
@@ -41,7 +41,7 @@ class CarlaCDASimAdapter:
         """
 
         # Create an XML-RPC server
-        print("Starting sensorlib XML-RPC server.")
+        logging.info("Starting sensorlib XML-RPC server.")
         server = SimpleXMLRPCServer((xmlrpc_server_host, xmlrpc_server_port))
         server.register_introspection_functions()
         server.register_function(self.__create_simulated_semantic_lidar_sensor,
@@ -67,6 +67,7 @@ class CarlaCDASimAdapter:
         # CARLA 0.9.10 has a bug where the y-axis value is negated.
         # To correct for this we are negating the request sensor location y
         # position
+        sensor_position[1] *= -1.0
         logging.info("Updated sensor position to " + sensor_position)
         simulated_sensor = self.__api.create_simulated_semantic_lidar_sensor(self.sensor_config["simulated_sensor"],
                                                                              self.sensor_config["lidar_sensor"],
@@ -134,9 +135,10 @@ if __name__ == "__main__":
         default="INFO",
         type=str,
         help="Log Level for service (default: INFO)")
+    
+    args = arg_parser.parse_args()
     level = logging.getLevelName(args.log_level)
     logging.getLogger().setLevel(level)
-    args = arg_parser.parse_args()
     sensor_api = CarlaCDASimAPI.build_from_host_spec(args.carla_host, args.carla_port)
     sensor_data_service = CarlaCDASimAdapter(sensor_api)
     sensor_data_service.start_xml_rpc_server(args.xmlrpc_server_host, args.xmlrpc_server_port, args.sensor_config_file, args.noise_model_config_file, args.detection_cycle_delay_seconds, True)


### PR DESCRIPTION

<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Negate y value for created sensors to account for inverted y-axis of carla
<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

<!-- e.g. CAR-123 -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
