### PR TITLE
Fix average speed math error

### DIFF
--- a/trajectory_utils/include/trajectory_utils/conversions/conversions.h
+++ b/trajectory_utils/include/trajectory_utils/conversions/conversions.h
@@ -23,15 +23,6 @@ namespace trajectory_utils
 namespace conversions
 {
 
-class negative_speed_from_conversion : public std::exception {
-    private:
-    std::string message_;
-
-    public:
-    negative_speed_from_conversion(const std::string& msg) : message_(msg) {}
-    char const* what() const throw() {return message_.c_str();};
-};
-
 /**
  * \brief Converts a list of speeds to a list of times for the corresponding downtrack points
  *
@@ -50,7 +41,7 @@ void speed_to_time(const std::vector<double>& downtrack, const std::vector<doubl
  * \param initial_speed
  * \param speeds Output parameter which points to the vector which will store the speeds at each point.
  *              The first speed will always be initial_speed
- * \throw negative_speed_from_conversion if more than -0.01 negative speed detected, which could indicate invalid trajectory input
+ * \throw std::runtime_error if more than -0.01 negative speed detected, which could indicate invalid trajectory input
  */
 void time_to_speed(const std::vector<double>& downtrack, const std::vector<double>& times, double initial_speed,
                    std::vector<double>* speeds);

--- a/trajectory_utils/include/trajectory_utils/conversions/conversions.h
+++ b/trajectory_utils/include/trajectory_utils/conversions/conversions.h
@@ -22,35 +22,46 @@ namespace trajectory_utils
 {
 namespace conversions
 {
+
+class negative_speed_from_conversion : public std::exception {
+    private:
+    std::string message_;
+
+    public:
+    negative_speed_from_conversion(const std::string& msg) : message_(msg) {}
+    char const* what() const throw() {return message_.c_str();};
+};
+
 /**
  * \brief Converts a list of speeds to a list of times for the corresponding downtrack points
- * 
+ *
  * \param downtracks The downtrack points where each speed and time will be
  * \param speeds The speed at each downtrack point. Must have the same length as the downtracks list
- * \param times Output parameter which points to the vector which will store the times at each point. 
+ * \param times Output parameter which points to the vector which will store the times at each point.
  *              The first time will always be 0 as the times are relative
  */
 void speed_to_time(const std::vector<double>& downtrack, const std::vector<double>& speeds, std::vector<double>* times);
 
 /**
  * \brief Converts a list of times to a list of speeds for the corresponding downtrack points
- * 
+ *
  * \param downtracks The downtrack points where each speed and time will be
  * \param times The time at each downtrack point. Must have the same length as the downtracks list
- * \param initial_speed 
- * \param speeds Output parameter which points to the vector which will store the speeds at each point. 
+ * \param initial_speed
+ * \param speeds Output parameter which points to the vector which will store the speeds at each point.
  *              The first speed will always be initial_speed
+ * \throw negative_speed_from_conversion if more than -0.01 negative speed detected, which could indicate invalid trajectory input
  */
 void time_to_speed(const std::vector<double>& downtrack, const std::vector<double>& times, double initial_speed,
                    std::vector<double>* speeds);
 
 /**
  * \brief Converts a list of times to a list of speeds for the corresponding downtrack points using constant jerk equations
- * 
+ *
  * \param downtracks The downtrack points where each speed and time will be
  * \param times The time at each downtrack point. Must have the same length as the downtracks list
- * \param initial_speed 
- * \param speeds Output parameter which points to the vector which will store the speeds at each point. 
+ * \param initial_speed
+ * \param speeds Output parameter which points to the vector which will store the speeds at each point.
  *              The first speed will always be initial_speed
  * \param decel_jerk The decelerating constant jerk used in calculation
  */
@@ -59,12 +70,12 @@ void time_to_speed_constjerk(const std::vector<double>& downtracks, const std::v
 
 /**
  * \brief Converts the trajectory points of a TrajectoryPlan message into equal sized vectors of downtrack distance and time
- * 
+ *
  * \param traj_points The trajectory points to convert
  * \param downtrack Output parameter which points to the vector which will store the resulting downtracks.
  * \param times Output parameter which points to the vector which will store the resulting downtracks
- * 
- */ 
+ *
+ */
 void trajectory_to_downtrack_time(const std::vector<cav_msgs::TrajectoryPlanPoint>& traj_points,
                                   std::vector<double>* downtrack, std::vector<double>* times);
 }  // namespace conversions

--- a/trajectory_utils/src/trajectory_utils/conversions/conversions.cpp
+++ b/trajectory_utils/src/trajectory_utils/conversions/conversions.cpp
@@ -147,7 +147,7 @@ void time_to_speed(const std::vector<double>& downtrack, const std::vector<doubl
 
   if (detected_negative_speed)
   {
-    throw std::runtime_error("Detected negative speed while converting from time to speed in trajectory. The most negative value detected was: " + std::to_string(detected_nagative_speed));
+    throw std::runtime_error("Detected negative speed while converting from time to speed in trajectory. The most negative value detected was: " + std::to_string(minimum_detected_speed));
   }
 }
 

--- a/trajectory_utils/src/trajectory_utils/conversions/conversions.cpp
+++ b/trajectory_utils/src/trajectory_utils/conversions/conversions.cpp
@@ -98,7 +98,7 @@ void time_to_speed(const std::vector<double>& downtrack, const std::vector<doubl
                    std::vector<double>* speeds)
 {
   bool detected_negative_speed = false;
-  double detected_nagative_speed = 0.0;
+  double minimum_detected_speed = 0.0;
   if (downtrack.size() != times.size())
   {
     throw std::invalid_argument("Input vector sizes do not match");
@@ -134,7 +134,7 @@ void time_to_speed(const std::vector<double>& downtrack, const std::vector<doubl
     if (cur_speed < -0.1)
     {
       detected_negative_speed = true;
-      detected_nagative_speed = std::min(cur_speed, detected_nagative_speed);
+      minimum_detected_speed = std::min(cur_speed, minimum_detected_speed);
     }
 
     cur_speed = std::max(0.0, cur_speed);
@@ -147,7 +147,7 @@ void time_to_speed(const std::vector<double>& downtrack, const std::vector<doubl
 
   if (detected_negative_speed)
   {
-    throw negative_speed_from_conversion("Detected negative speed while converting from time to speed in trajectory. The most negative value detected was: " + std::to_string(detected_nagative_speed));
+    throw std::runtime_error("Detected negative speed while converting from time to speed in trajectory. The most negative value detected was: " + std::to_string(detected_nagative_speed));
   }
 }
 

--- a/trajectory_utils/src/trajectory_utils/conversions/conversions.cpp
+++ b/trajectory_utils/src/trajectory_utils/conversions/conversions.cpp
@@ -97,6 +97,8 @@ void speed_to_time(const std::vector<double>& downtrack, const std::vector<doubl
 void time_to_speed(const std::vector<double>& downtrack, const std::vector<double>& times, double initial_speed,
                    std::vector<double>* speeds)
 {
+  bool detected_negative_speed = false;
+  double detected_nagative_speed = 0.0;
   if (downtrack.size() != times.size())
   {
     throw std::invalid_argument("Input vector sizes do not match");
@@ -123,15 +125,29 @@ void time_to_speed(const std::vector<double>& downtrack, const std::vector<doubl
     double cur_speed;
 
     cur_speed = (2.0 * delta_d / dt) - prev_speed;
+    // first speed value is often the measured speed, which can
+    // be small negative number when stopping (it happens in simulation for example)
+    // which is not an error and can be set to 0.0 safely. However, if large
+    // negative speed is detected, it most certainly has error in the given trajectory.
+    // The function throws in the end to indicate the user, while trying its best to
+    // continue converting by treating negative speed as 0.
+    if (cur_speed < -0.1)
+    {
+      detected_negative_speed = true;
+      detected_nagative_speed = std::min(cur_speed, detected_nagative_speed);
+    }
 
-    // can't have negative speed!
     cur_speed = std::max(0.0, cur_speed);
-
     speeds->push_back(cur_speed);
 
     prev_position = cur_pos;
     prev_time = cur_time;
     prev_speed = cur_speed;
+  }
+
+  if (detected_negative_speed)
+  {
+    throw negative_speed_from_conversion("Detected negative speed while converting from time to speed in trajectory. The most negative value detected was: " + std::to_string(detected_nagative_speed));
   }
 }
 

--- a/trajectory_utils/src/trajectory_utils/conversions/conversions.cpp
+++ b/trajectory_utils/src/trajectory_utils/conversions/conversions.cpp
@@ -123,7 +123,10 @@ void time_to_speed(const std::vector<double>& downtrack, const std::vector<doubl
     double cur_speed;
 
     cur_speed = (2.0 * delta_d / dt) - prev_speed;
-    
+
+    // can't have negative speed!
+    cur_speed = std::max(0.0, cur_speed);
+
     speeds->push_back(cur_speed);
 
     prev_position = cur_pos;
@@ -160,7 +163,7 @@ void time_to_speed_constjerk(const std::vector<double>& downtrack, const std::ve
 
     double cur_speed;
     double jerk_min = 0.01; //Min stop and wait jerk
-    
+
     if(decel_jerk > jerk_min){
       cur_speed = prev_speed - 0.5* decel_jerk*pow(dt,2);
       cur_speed = std::max(0.0,cur_speed);
@@ -169,11 +172,11 @@ void time_to_speed_constjerk(const std::vector<double>& downtrack, const std::ve
       // stop and wait plugin doesn't create slow down traj for very low jerk requirement
       cur_speed = prev_speed;
     }
-    
+
     if(std::abs(delta_d) <= 0.0001){
       cur_speed =0.0;
     }
-      
+
     speeds->push_back(cur_speed);
 
     prev_position = cur_pos;

--- a/trajectory_utils_ros2/include/trajectory_utils/conversions/conversions.hpp
+++ b/trajectory_utils_ros2/include/trajectory_utils/conversions/conversions.hpp
@@ -25,15 +25,6 @@ namespace trajectory_utils
 namespace conversions
 {
 
-class negative_speed_from_conversion : public std::exception {
-    private:
-    std::string message_;
-
-    public:
-    negative_speed_from_conversion(const std::string& msg) : message_(msg) {}
-    char const* what() const throw() {return message_.c_str();};
-};
-
 /**
  * \brief Converts a list of speeds to a list of times for the corresponding downtrack points
  *
@@ -52,7 +43,7 @@ void speed_to_time(const std::vector<double>& downtrack, const std::vector<doubl
  * \param initial_speed
  * \param speeds Output parameter which points to the vector which will store the speeds at each point.
  *              The first speed will always be initial_speed
- * \throw negative_speed_from_conversion if more than -0.01 negative speed detected, which could indicate invalid trajectory input
+ * \throw std::runtime_error if less than -0.01 speed detected, which could indicate invalid trajectory input
  */
 void time_to_speed(const std::vector<double>& downtrack, const std::vector<double>& times, double initial_speed,
                    std::vector<double>* speeds);

--- a/trajectory_utils_ros2/include/trajectory_utils/conversions/conversions.hpp
+++ b/trajectory_utils_ros2/include/trajectory_utils/conversions/conversions.hpp
@@ -24,35 +24,46 @@ namespace trajectory_utils
 {
 namespace conversions
 {
+
+class negative_speed_from_conversion : public std::exception {
+    private:
+    std::string message_;
+
+    public:
+    negative_speed_from_conversion(const std::string& msg) : message_(msg) {}
+    char const* what() const throw() {return message_.c_str();};
+};
+
 /**
  * \brief Converts a list of speeds to a list of times for the corresponding downtrack points
- * 
+ *
  * \param downtracks The downtrack points where each speed and time will be
  * \param speeds The speed at each downtrack point. Must have the same length as the downtracks list
- * \param times Output parameter which points to the vector which will store the times at each point. 
+ * \param times Output parameter which points to the vector which will store the times at each point.
  *              The first time will always be 0 as the times are relative
  */
 void speed_to_time(const std::vector<double>& downtrack, const std::vector<double>& speeds, std::vector<double>* times);
 
 /**
  * \brief Converts a list of times to a list of speeds for the corresponding downtrack points
- * 
+ *
  * \param downtracks The downtrack points where each speed and time will be
  * \param times The time at each downtrack point. Must have the same length as the downtracks list
- * \param initial_speed 
- * \param speeds Output parameter which points to the vector which will store the speeds at each point. 
+ * \param initial_speed
+ * \param speeds Output parameter which points to the vector which will store the speeds at each point.
  *              The first speed will always be initial_speed
+ * \throw negative_speed_from_conversion if more than -0.01 negative speed detected, which could indicate invalid trajectory input
  */
 void time_to_speed(const std::vector<double>& downtrack, const std::vector<double>& times, double initial_speed,
                    std::vector<double>* speeds);
 
 /**
  * \brief Converts a list of times to a list of speeds for the corresponding downtrack points using constant jerk equations
- * 
+ *
  * \param downtracks The downtrack points where each speed and time will be
  * \param times The time at each downtrack point. Must have the same length as the downtracks list
- * \param initial_speed 
- * \param speeds Output parameter which points to the vector which will store the speeds at each point. 
+ * \param initial_speed
+ * \param speeds Output parameter which points to the vector which will store the speeds at each point.
  *              The first speed will always be initial_speed
  * \param decel_jerk The decelerating constant jerk used in calculation
  */
@@ -61,12 +72,12 @@ void time_to_speed_constjerk(const std::vector<double>& downtracks, const std::v
 
 /**
  * \brief Converts the trajectory points of a TrajectoryPlan message into equal sized vectors of downtrack distance and time
- * 
+ *
  * \param traj_points The trajectory points to convert
  * \param downtrack Output parameter which points to the vector which will store the resulting downtracks.
  * \param times Output parameter which points to the vector which will store the resulting downtracks
- * 
- */ 
+ *
+ */
 void trajectory_to_downtrack_time(const std::vector<carma_planning_msgs::msg::TrajectoryPlanPoint>& traj_points,
                                   std::vector<double>* downtrack, std::vector<double>* times);
 }  // namespace conversions

--- a/trajectory_utils_ros2/src/trajectory_utils/conversions/conversions.cpp
+++ b/trajectory_utils_ros2/src/trajectory_utils/conversions/conversions.cpp
@@ -144,7 +144,7 @@ void time_to_speed(const std::vector<double>& downtrack, const std::vector<doubl
 
   if (detected_negative_speed)
   {
-    throw std::runtime_error("Detected negative speed while converting from time to speed in trajectory. The most negative value detected was: " + std::to_string(detected_nagative_speed));
+    throw std::runtime_error("Detected negative speed while converting from time to speed in trajectory. The most negative value detected was: " + std::to_string(minimum_detected_speed));
   }
 }
 

--- a/trajectory_utils_ros2/src/trajectory_utils/conversions/conversions.cpp
+++ b/trajectory_utils_ros2/src/trajectory_utils/conversions/conversions.cpp
@@ -94,6 +94,8 @@ void speed_to_time(const std::vector<double>& downtrack, const std::vector<doubl
 void time_to_speed(const std::vector<double>& downtrack, const std::vector<double>& times, double initial_speed,
                    std::vector<double>* speeds)
 {
+  bool detected_negative_speed = false;
+  double detected_nagative_speed = 0.0;
   if (downtrack.size() != times.size())
   {
     throw std::invalid_argument("Input vector sizes do not match");
@@ -120,15 +122,29 @@ void time_to_speed(const std::vector<double>& downtrack, const std::vector<doubl
     double cur_speed;
 
     cur_speed = (2.0 * delta_d / dt) - prev_speed;
+    // first speed value is often the measured speed, which can
+    // be small negative number when stopping (it happens in simulation for example)
+    // which is not an error and can be set to 0.0 safely. However, if large
+    // negative speed is detected, it most certainly has error in the given trajectory.
+    // The function throws in the end to indicate the user, while trying its best to
+    // continue converting by treating negative speed as 0.
+    if (cur_speed < -0.1)
+    {
+      detected_negative_speed = true;
+      detected_nagative_speed = std::min(cur_speed, detected_nagative_speed);
+    }
 
-    // can't have negative speed!
     cur_speed = std::max(0.0, cur_speed);
-
     speeds->push_back(cur_speed);
 
     prev_position = cur_pos;
     prev_time = cur_time;
     prev_speed = cur_speed;
+  }
+
+  if (detected_negative_speed)
+  {
+    throw negative_speed_from_conversion("Detected negative speed while converting from time to speed in trajectory. The most negative value detected was: " + std::to_string(detected_nagative_speed));
   }
 }
 

--- a/trajectory_utils_ros2/src/trajectory_utils/conversions/conversions.cpp
+++ b/trajectory_utils_ros2/src/trajectory_utils/conversions/conversions.cpp
@@ -110,6 +110,7 @@ void time_to_speed(const std::vector<double>& downtrack, const std::vector<doubl
   double prev_speed = initial_speed;
   double prev_time = times[0];
   speeds->push_back(prev_speed);
+  RCLCPP_ERROR_STREAM(rclcpp::get_logger("todo"), "start time_to_speed: " << prev_speed );
   for (int i = 1; i < downtrack.size(); i++)
   {
     double cur_pos = downtrack[i];
@@ -120,7 +121,11 @@ void time_to_speed(const std::vector<double>& downtrack, const std::vector<doubl
     double cur_speed;
 
     cur_speed = (2.0 * delta_d / dt) - prev_speed;
-    
+    RCLCPP_ERROR_STREAM(rclcpp::get_logger("todo"), "time_to_speed: " << cur_speed );
+
+    // can't have negative speed!
+    cur_speed = std::max(0.0, cur_speed);
+
     speeds->push_back(cur_speed);
 
     prev_position = cur_pos;
@@ -157,7 +162,7 @@ void time_to_speed_constjerk(const std::vector<double>& downtrack, const std::ve
 
     double cur_speed;
     double jerk_min = 0.01; //Min stop and wait jerk
-    
+
     if(decel_jerk > jerk_min){
       cur_speed = prev_speed - 0.5* decel_jerk*pow(dt,2);
       cur_speed = std::max(0.0,cur_speed);
@@ -166,11 +171,11 @@ void time_to_speed_constjerk(const std::vector<double>& downtrack, const std::ve
       // stop and wait plugin doesn't create slow down traj for very low jerk requirement
       cur_speed = prev_speed;
     }
-    
+
     if(std::abs(delta_d) <= 0.0001){
       cur_speed =0.0;
     }
-      
+
     speeds->push_back(cur_speed);
 
     prev_position = cur_pos;

--- a/trajectory_utils_ros2/src/trajectory_utils/conversions/conversions.cpp
+++ b/trajectory_utils_ros2/src/trajectory_utils/conversions/conversions.cpp
@@ -95,7 +95,7 @@ void time_to_speed(const std::vector<double>& downtrack, const std::vector<doubl
                    std::vector<double>* speeds)
 {
   bool detected_negative_speed = false;
-  double detected_nagative_speed = 0.0;
+  double minimum_detected_speed = 0.0;
   if (downtrack.size() != times.size())
   {
     throw std::invalid_argument("Input vector sizes do not match");
@@ -131,7 +131,7 @@ void time_to_speed(const std::vector<double>& downtrack, const std::vector<doubl
     if (cur_speed < -0.1)
     {
       detected_negative_speed = true;
-      detected_nagative_speed = std::min(cur_speed, detected_nagative_speed);
+      minimum_detected_speed = std::min(cur_speed, minimum_detected_speed);
     }
 
     cur_speed = std::max(0.0, cur_speed);
@@ -144,7 +144,7 @@ void time_to_speed(const std::vector<double>& downtrack, const std::vector<doubl
 
   if (detected_negative_speed)
   {
-    throw negative_speed_from_conversion("Detected negative speed while converting from time to speed in trajectory. The most negative value detected was: " + std::to_string(detected_nagative_speed));
+    throw std::runtime_error("Detected negative speed while converting from time to speed in trajectory. The most negative value detected was: " + std::to_string(detected_nagative_speed));
   }
 }
 

--- a/trajectory_utils_ros2/src/trajectory_utils/conversions/conversions.cpp
+++ b/trajectory_utils_ros2/src/trajectory_utils/conversions/conversions.cpp
@@ -110,7 +110,6 @@ void time_to_speed(const std::vector<double>& downtrack, const std::vector<doubl
   double prev_speed = initial_speed;
   double prev_time = times[0];
   speeds->push_back(prev_speed);
-  RCLCPP_ERROR_STREAM(rclcpp::get_logger("todo"), "start time_to_speed: " << prev_speed );
   for (int i = 1; i < downtrack.size(); i++)
   {
     double cur_pos = downtrack[i];
@@ -121,7 +120,6 @@ void time_to_speed(const std::vector<double>& downtrack, const std::vector<doubl
     double cur_speed;
 
     cur_speed = (2.0 * delta_d / dt) - prev_speed;
-    RCLCPP_ERROR_STREAM(rclcpp::get_logger("todo"), "time_to_speed: " << cur_speed );
 
     // can't have negative speed!
     cur_speed = std::max(0.0, cur_speed);


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR handles a case where the measured speed value when stopping can be negative value, which we can be set to 0 safely. 

However, if it is a large negative value, the only way it can happen is if the initial trajectory generation is wrong. So this function throws an exception to indicate the user. This forces the developer to generate physics-conforming trajectory. Previously this case was handled by forcing it 0, but it wasn't applying at the correct place. Now it still applies 0 to negative values as a safety feature.

This throw behavior caught an error in the stop_and_wait_plugin at this time, which is partially handled in this PR: https://github.com/usdot-fhwa-stol/carma-platform/pull/2272

## Related GitHub Issue
https://github.com/usdot-fhwa-stol/carma-utils/issues/211
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
https://usdot-carma.atlassian.net/browse/CDAR-717
CDAR-717
<!-- e.g. CAR-123 -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
cdasim pc 1 integration tested with vru use case 1
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
