### PR TITLE
Add Clang-Tidy integration for carma_ros2_utils

### DIFF
--- a/carma_ros2_utils/.clang-tidy
+++ b/carma_ros2_utils/.clang-tidy
@@ -1,0 +1,14 @@
+---
+Checks: >-
+  bugprone-*,
+  cert-*,
+  clang-analyzer-*,
+  concurrency-*,
+  cppcoreguidelines-*,
+  misc-*,
+  modernize-*,
+  performance-*,
+  portability-*,
+  readability-*
+FormatStyle: "file"
+HeaderFilterRegex: ".*"

--- a/carma_ros2_utils/CMakeLists.txt
+++ b/carma_ros2_utils/CMakeLists.txt
@@ -9,6 +9,8 @@ find_package(ament_cmake_auto REQUIRED)
 find_package(ament_cmake_python REQUIRED)
 ament_auto_find_build_dependencies()
 
+# The generated compilation database is helpful with code completion in IDEs and linting tools
+set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 
 # Includes
 include_directories(

--- a/carma_ros2_utils/package.xml
+++ b/carma_ros2_utils/package.xml
@@ -35,6 +35,7 @@
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>carma_ament_cmake_clang_tidy</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>

--- a/carma_ros2_utils/package.xml
+++ b/carma_ros2_utils/package.xml
@@ -35,7 +35,7 @@
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
-  <test_depend>carma_ament_cmake_clang_tidy</test_depend>
+  <test_depend>ament_cmake_clang_tidy</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>

--- a/carma_ros2_utils/test/CMakeLists.txt
+++ b/carma_ros2_utils/test/CMakeLists.txt
@@ -4,7 +4,11 @@ find_package(ros2_lifecycle_manager REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(ament_cmake_pytest REQUIRED)
-find_package(launch_testing_ament_cmake REQUIRED) 
+find_package(launch_testing_ament_cmake REQUIRED)
+find_package(carma_ament_cmake_clang_tidy REQUIRED)
+
+set(carma_ament_cmake_clang_tidy_CONFIG_FILE ${PROJECT_SOURCE_DIR}/.clang-tidy)
+carma_ament_clang_tidy(${PROJECT_BINARY_DIR})
 
 set(dependencies ${dependencies} ros2_lifecycle_manager std_srvs)
 
@@ -104,10 +108,10 @@ install(
   # EXPORT should not be needed for unit tests
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib/${PROJECT_NAME}
-  RUNTIME DESTINATION lib/${PROJECT_NAME} # In Ament, Executables are installed to lib/${PROJECT_NAME} not bin 
+  RUNTIME DESTINATION lib/${PROJECT_NAME} # In Ament, Executables are installed to lib/${PROJECT_NAME} not bin
   INCLUDES DESTINATION include
 )
 
-# This is a bit of a hack to allow for rclcpp_component registration in this subdirectory 
+# This is a bit of a hack to allow for rclcpp_component registration in this subdirectory
 # Based off sloretz's answer from ROS Answers here https://answers.ros.org/question/361289/ros2-components-registration-from-subdirectory-cmakelists-file/
 #set(AMENT_EXTENSIONS_ament_package ${AMENT_EXTENSIONS_ament_package} PARENT_SCOPE)

--- a/carma_ros2_utils/test/CMakeLists.txt
+++ b/carma_ros2_utils/test/CMakeLists.txt
@@ -5,10 +5,10 @@ find_package(std_srvs REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(ament_cmake_pytest REQUIRED)
 find_package(launch_testing_ament_cmake REQUIRED)
-find_package(carma_ament_cmake_clang_tidy REQUIRED)
+find_package(ament_cmake_clang_tidy REQUIRED)
 
-set(carma_ament_cmake_clang_tidy_CONFIG_FILE ${PROJECT_SOURCE_DIR}/.clang-tidy)
-carma_ament_clang_tidy(${PROJECT_BINARY_DIR})
+set(ament_cmake_clang_tidy_CONFIG_FILE ${PROJECT_SOURCE_DIR}/.clang-tidy)
+ament_clang_tidy(${PROJECT_BINARY_DIR})
 
 set(dependencies ${dependencies} ros2_lifecycle_manager std_srvs)
 


### PR DESCRIPTION
# PR Details
## Description

This PR adds Clang-Tidy integration into the `carma_ros2_utils` package. Adding Clang-Tidy support will help improve and maintain software quality for this package. It supplements the checks that SonarQube does.

## Related GitHub Issue

## Related Jira Key

Closes [CDAR-737](https://usdot-carma.atlassian.net/browse/CDAR-737)

## Motivation and Context

Improve software quality

## How Has This Been Tested?

Run as part of `colcon` build

## Types of changes

- [x] New feature (non-breaking change that adds functionality)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] All new and existing tests passed.
