### PR TITLE
Make `ros2_lifecycle_manager` package compatible with Humble

### DIFF
--- a/ros2_lifecycle_manager/src/ros2_lifecycle_manager.cpp
+++ b/ros2_lifecycle_manager/src/ros2_lifecycle_manager.cpp
@@ -292,7 +292,7 @@ namespace ros2_lifecycle_manager
             node_logging_->get_logger(), "Calling node: " << node.node_name);
 
         // Call service
-        auto future_result = static_cast<ChangeStateSharedFutureWithRequest const &>(node.change_state_client->async_send_request(request, [](ChangeStateSharedFutureWithRequest) {}));
+        auto future_result{node.change_state_client->async_send_request(request, [](ChangeStateSharedFutureWithRequest) {})};
 
         // Wait for response
         if (!wait_on_change_state_future(future_result, call_timeout))
@@ -320,7 +320,8 @@ namespace ros2_lifecycle_manager
             node_logging_->get_logger(), "Calling node a-sync: " << node.node_name);
 
         // Call service and record future
-        futures.emplace_back(detail::get_future(node.change_state_client->async_send_request(request, [](ChangeStateSharedFutureWithRequest) {})));
+        // TODO(CAR-6014): Remove static cast when CARMA Platform drops ROS Foxy support
+        futures.emplace_back(static_cast<const ChangeStateSharedFutureWithRequest &>(node.change_state_client->async_send_request(request, [](ChangeStateSharedFutureWithRequest) {})));
         future_node_map.emplace(futures.size() - 1, node.node_name);
       }
       size_t i = 0;


### PR DESCRIPTION
# PR Details
## Description

This PR resolves issues that prevented the `ros2_lifecycle_manager` package from building on ROS 2 Humble. It removes the deprecated `callback_group` namespace that was removed between Foxy and Humble. 

It also disambiguates the conversion function call when converting from a `rclcpp::Client` future type to its underlying `std::shared_future`. There was an API change between Foxy and Humble, but we have to rely on some of the deprecated implicit conversions until we can drop Foxy.

## Related GitHub Issue

## Related Jira Key

Closes [CF-802](https://usdot-carma.atlassian.net/browse/CF-802)
Progresses [CF-793](https://usdot-carma.atlassian.net/browse/CF-793)

## Motivation and Context

Needed changes to get some necessary CARMA Platform packages to build on Humble.

## How Has This Been Tested?

Compilation only

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.


[CF-802]: https://usdot-carma.atlassian.net/browse/CF-802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CF-793]: https://usdot-carma.atlassian.net/browse/CF-793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ