### PR TITLE
Update `ros2_lifecycle_manager` tests to be compatible with Humble

### DIFF
--- a/ros2_lifecycle_manager/test/test_lifecycle_manager.cpp
+++ b/ros2_lifecycle_manager/test/test_lifecycle_manager.cpp
@@ -65,9 +65,9 @@ TEST(LifecycleManagerTest, BasicTest)
   auto spin_future{std::async(std::launch::async, [&executor]
                               { executor.spin(); })};
 
-  ASSERT_EQ((uint8_t)2, managed_nodes.size());
-  ASSERT_EQ((uint8_t)0, managed_nodes[0].compare("test_lifecycle_node_1"));
-  ASSERT_EQ((uint8_t)0, managed_nodes[1].compare("test_lifecycle_node_2"));
+  ASSERT_EQ(static_cast<std::size_t>(2U), managed_nodes.size());
+  ASSERT_EQ(0, managed_nodes[0].compare("test_lifecycle_node_1"));
+  ASSERT_EQ(0, managed_nodes[1].compare("test_lifecycle_node_2"));
 
   // Test get managed node states
   ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_1"));

--- a/ros2_lifecycle_manager/test/test_lifecycle_manager.cpp
+++ b/ros2_lifecycle_manager/test/test_lifecycle_manager.cpp
@@ -20,9 +20,7 @@
 #include <future>
 #include <memory>
 #include <thread>
-#include <future>
-#include "rclcpp/rclcpp.hpp"
-#include "rclcpp_lifecycle/lifecycle_node.hpp"
+#include <utility>
 
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_lifecycle/lifecycle_node.hpp>

--- a/ros2_lifecycle_manager/test/test_lifecycle_manager.cpp
+++ b/ros2_lifecycle_manager/test/test_lifecycle_manager.cpp
@@ -15,121 +15,117 @@
  */
 
 #include <gtest/gtest.h>
-#include <memory>
+
 #include <chrono>
+#include <future>
+#include <memory>
 #include <thread>
 #include <future>
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_lifecycle/lifecycle_node.hpp>
+
 #include "ros2_lifecycle_manager/ros2_lifecycle_manager.hpp"
-#include "boost/core/ignore_unused.hpp"
 
 
 using std_msec = std::chrono::milliseconds;
 
 /**
- * This test is meant to exercise the standard flow of the lifecycle manager. 
- * To allow for callbacks to be processed the test makes use of a rather roundabout thread paradigm 
+ * This test is meant to exercise the standard flow of the lifecycle manager.
+ * To allow for callbacks to be processed the test makes use of a rather roundabout thread paradigm
  * Care should be taken to understand this code before trying to duplicate it in other test scenarios.
  * There may be better approaches such as the launch_testing framework.
- */ 
+ */
 TEST(LifecycleManagerTest, BasicTest)
 {
   // Test constructor
   auto node = std::make_shared<rclcpp::Node>("lifecycle_manager_test_node"); // Node to connect to ROS network
 
-  auto ret = rcutils_logging_set_logger_level(
-        node->get_logger().get_name(), RCUTILS_LOG_SEVERITY_DEBUG);
-  boost::ignore_unused(ret);
+  std::ignore = rcutils_logging_set_logger_level(
+      node->get_logger().get_name(), RCUTILS_LOG_SEVERITY_DEBUG);
 
-  std::promise<bool> promise_test_result; // Promise which will be used to spin the node until the test completes
-  std::shared_future<bool> future_test_result(promise_test_result.get_future()); // Future to check for spin
+  ros2_lifecycle_manager::Ros2LifecycleManager lifecycle_mgr_( // Construct lifecycle manager
+      node->get_node_base_interface(),
+      node->get_node_graph_interface(),
+      node->get_node_logging_interface(),
+      node->get_node_services_interface());
 
-  std::thread test_thread([&promise_test_result, node](){
-    
-    ros2_lifecycle_manager::Ros2LifecycleManager lifecycle_mgr_( // Construct lifecycle manager
-      node->get_node_base_interface(), 
-      node->get_node_graph_interface(), 
-      node->get_node_logging_interface(), 
-      node->get_node_services_interface()
-    );
+  // Test set_managed_nodes
+  lifecycle_mgr_.set_managed_nodes({"test_lifecycle_node_1", "test_lifecycle_node_2"});
 
-    // Test set_managed_nodes
-    lifecycle_mgr_.set_managed_nodes( { "test_lifecycle_node_1", "test_lifecycle_node_2" } );
-    
-    std::this_thread::sleep_for(std_msec(2000));
+  std::this_thread::sleep_for(std_msec(2000));
 
-    // Test get_managed_nodes
-    auto managed_nodes = lifecycle_mgr_.get_managed_nodes();
-    
-    ASSERT_EQ((uint8_t)2, managed_nodes.size());
-    ASSERT_EQ((uint8_t)0, managed_nodes[0].compare("test_lifecycle_node_1"));
-    ASSERT_EQ((uint8_t)0, managed_nodes[1].compare("test_lifecycle_node_2"));
-    
-    // Test get managed node states
-    ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_1"));
-    ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_2"));
-    ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN, lifecycle_mgr_.get_managed_node_state("unknown_node"));
-
-    // Test Configure
-    ASSERT_TRUE(lifecycle_mgr_.configure(std_msec(2000), std_msec(2000)).empty());
-    ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_1"));
-    ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_2"));
-
-    // Test Activate
-    ASSERT_TRUE(lifecycle_mgr_.activate(std_msec(2000), std_msec(2000)).empty());
-    ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE , lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_1"));
-    ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE , lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_2"));
-
-    // Test Deactivate
-    ASSERT_TRUE(lifecycle_mgr_.deactivate(std_msec(2000), std_msec(2000)).empty());
-    ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_1"));
-    ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_2"));
-
-    // Test cleanup
-    ASSERT_TRUE(lifecycle_mgr_.cleanup(std_msec(2000), std_msec(2000)).empty());
-    ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED , lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_1"));
-    ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED , lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_2"));
-
-    RCLCPP_INFO(node->get_logger(), "Using requested state methods");
-
-    // Bring to active via requested state
-    ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, lifecycle_mgr_.transition_node_to_state(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, "test_lifecycle_node_1", std_msec(2000), std_msec(2000)));
-    ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_1"));
-
-    ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, lifecycle_mgr_.transition_node_to_state(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, "test_lifecycle_node_2", std_msec(2000), std_msec(2000)));
-    ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_2"));
-
-    // Bring to unconfigured via requested state
-    ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, lifecycle_mgr_.transition_node_to_state(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, "test_lifecycle_node_1", std_msec(2000), std_msec(2000)));
-    ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_1"));
-
-    ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, lifecycle_mgr_.transition_node_to_state(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, "test_lifecycle_node_2", std_msec(2000), std_msec(2000)));
-    ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_2"));
-
-    RCLCPP_INFO(node->get_logger(), "Done with requested state methods");
-
-    // Bring back to active then shutdown via transitions
-    ASSERT_TRUE(lifecycle_mgr_.configure(std_msec(2000), std_msec(2000)).empty());
-    ASSERT_TRUE(lifecycle_mgr_.activate(std_msec(2000), std_msec(2000)).empty());
-    ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE , lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_1"));
-    ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE , lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_2"));
-
-    ASSERT_TRUE(lifecycle_mgr_.shutdown(std_msec(2000), std_msec(2000)).empty());
-    ASSERT_TRUE(lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED  == lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_1")
-                || lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN  == lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_1"));
-    ASSERT_TRUE(lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED  == lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_2")
-                || lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN  == lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_2"));
-
-    promise_test_result.set_value(true);
-  });
+  // Test get_managed_nodes
+  auto managed_nodes = lifecycle_mgr_.get_managed_nodes();
 
   RCLCPP_INFO(node->get_logger(), "Spinning");
-  rclcpp::spin_until_future_complete(node, future_test_result);
 
-  test_thread.join(); // Ensure thread closes
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
 
-  
+  auto spin_future{std::async(std::launch::async, [&executor]
+                              { executor.spin(); })};
+
+  ASSERT_EQ((uint8_t)2, managed_nodes.size());
+  ASSERT_EQ((uint8_t)0, managed_nodes[0].compare("test_lifecycle_node_1"));
+  ASSERT_EQ((uint8_t)0, managed_nodes[1].compare("test_lifecycle_node_2"));
+
+  // Test get managed node states
+  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_1"));
+  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_2"));
+  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN, lifecycle_mgr_.get_managed_node_state("unknown_node"));
+
+  // Test Configure
+  ASSERT_TRUE(lifecycle_mgr_.configure(std_msec(2000), std_msec(2000)).empty());
+  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_1"));
+  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_2"));
+
+  // Test Activate
+  ASSERT_TRUE(lifecycle_mgr_.activate(std_msec(2000), std_msec(2000)).empty());
+  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_1"));
+  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_2"));
+
+  // Test Deactivate
+  ASSERT_TRUE(lifecycle_mgr_.deactivate(std_msec(2000), std_msec(2000)).empty());
+  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_1"));
+  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_2"));
+
+  // Test cleanup
+  ASSERT_TRUE(lifecycle_mgr_.cleanup(std_msec(2000), std_msec(2000)).empty());
+  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_1"));
+  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_2"));
+
+  RCLCPP_INFO(node->get_logger(), "Using requested state methods");
+
+  // Bring to active via requested state
+  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, lifecycle_mgr_.transition_node_to_state(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, "test_lifecycle_node_1", std_msec(2000), std_msec(2000)));
+  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_1"));
+
+  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, lifecycle_mgr_.transition_node_to_state(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, "test_lifecycle_node_2", std_msec(2000), std_msec(2000)));
+  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_2"));
+
+  // Bring to unconfigured via requested state
+  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, lifecycle_mgr_.transition_node_to_state(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, "test_lifecycle_node_1", std_msec(2000), std_msec(2000)));
+  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_1"));
+
+  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, lifecycle_mgr_.transition_node_to_state(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, "test_lifecycle_node_2", std_msec(2000), std_msec(2000)));
+  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_2"));
+
+  RCLCPP_INFO(node->get_logger(), "Done with requested state methods");
+
+  // Bring back to active then shutdown via transitions
+  ASSERT_TRUE(lifecycle_mgr_.configure(std_msec(2000), std_msec(2000)).empty());
+  ASSERT_TRUE(lifecycle_mgr_.activate(std_msec(2000), std_msec(2000)).empty());
+  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_1"));
+  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_2"));
+
+  ASSERT_TRUE(lifecycle_mgr_.shutdown(std_msec(2000), std_msec(2000)).empty());
+  ASSERT_TRUE(lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED == lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_1") || lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN == lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_1"));
+  ASSERT_TRUE(lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED == lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_2") || lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN == lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_2"));
+
+  executor.cancel();
 }
 
 int main(int argc, char ** argv)
@@ -139,8 +135,7 @@ int main(int argc, char ** argv)
   // initialize ROS
   rclcpp::init(argc, argv);
 
-
-  bool success = RUN_ALL_TESTS();  
+  bool success = RUN_ALL_TESTS();
 
   // shutdown ROS
   rclcpp::shutdown();

--- a/ros2_lifecycle_manager/test/test_lifecycle_manager.cpp
+++ b/ros2_lifecycle_manager/test/test_lifecycle_manager.cpp
@@ -27,8 +27,7 @@
 
 #include "ros2_lifecycle_manager/ros2_lifecycle_manager.hpp"
 
-
-using std_msec = std::chrono::milliseconds;
+using std::chrono_literals::operator""ms;
 
 /**
  * This test is meant to exercise the standard flow of the lifecycle manager.
@@ -53,7 +52,7 @@ TEST(LifecycleManagerTest, BasicTest)
   // Test set_managed_nodes
   lifecycle_mgr_.set_managed_nodes({"test_lifecycle_node_1", "test_lifecycle_node_2"});
 
-  std::this_thread::sleep_for(std_msec(2000));
+  std::this_thread::sleep_for(2000ms);
 
   // Test get_managed_nodes
   auto managed_nodes = lifecycle_mgr_.get_managed_nodes();
@@ -76,50 +75,50 @@ TEST(LifecycleManagerTest, BasicTest)
   ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN, lifecycle_mgr_.get_managed_node_state("unknown_node"));
 
   // Test Configure
-  ASSERT_TRUE(lifecycle_mgr_.configure(std_msec(2000), std_msec(2000)).empty());
+  ASSERT_TRUE(lifecycle_mgr_.configure(2000ms, 2000ms).empty());
   ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_1"));
   ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_2"));
 
   // Test Activate
-  ASSERT_TRUE(lifecycle_mgr_.activate(std_msec(2000), std_msec(2000)).empty());
+  ASSERT_TRUE(lifecycle_mgr_.activate(2000ms, 2000ms).empty());
   ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_1"));
   ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_2"));
 
   // Test Deactivate
-  ASSERT_TRUE(lifecycle_mgr_.deactivate(std_msec(2000), std_msec(2000)).empty());
+  ASSERT_TRUE(lifecycle_mgr_.deactivate(2000ms, 2000ms).empty());
   ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_1"));
   ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_2"));
 
   // Test cleanup
-  ASSERT_TRUE(lifecycle_mgr_.cleanup(std_msec(2000), std_msec(2000)).empty());
+  ASSERT_TRUE(lifecycle_mgr_.cleanup(2000ms, 2000ms).empty());
   ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_1"));
   ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_2"));
 
   RCLCPP_INFO(node->get_logger(), "Using requested state methods");
 
   // Bring to active via requested state
-  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, lifecycle_mgr_.transition_node_to_state(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, "test_lifecycle_node_1", std_msec(2000), std_msec(2000)));
+  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, lifecycle_mgr_.transition_node_to_state(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, "test_lifecycle_node_1", 2000ms, 2000ms));
   ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_1"));
 
-  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, lifecycle_mgr_.transition_node_to_state(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, "test_lifecycle_node_2", std_msec(2000), std_msec(2000)));
+  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, lifecycle_mgr_.transition_node_to_state(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, "test_lifecycle_node_2", 2000ms, 2000ms));
   ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_2"));
 
   // Bring to unconfigured via requested state
-  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, lifecycle_mgr_.transition_node_to_state(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, "test_lifecycle_node_1", std_msec(2000), std_msec(2000)));
+  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, lifecycle_mgr_.transition_node_to_state(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, "test_lifecycle_node_1", 2000ms, 2000ms));
   ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_1"));
 
-  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, lifecycle_mgr_.transition_node_to_state(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, "test_lifecycle_node_2", std_msec(2000), std_msec(2000)));
+  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, lifecycle_mgr_.transition_node_to_state(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, "test_lifecycle_node_2", 2000ms, 2000ms));
   ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_2"));
 
   RCLCPP_INFO(node->get_logger(), "Done with requested state methods");
 
   // Bring back to active then shutdown via transitions
-  ASSERT_TRUE(lifecycle_mgr_.configure(std_msec(2000), std_msec(2000)).empty());
-  ASSERT_TRUE(lifecycle_mgr_.activate(std_msec(2000), std_msec(2000)).empty());
+  ASSERT_TRUE(lifecycle_mgr_.configure(2000ms, 2000ms).empty());
+  ASSERT_TRUE(lifecycle_mgr_.activate(2000ms, 2000ms).empty());
   ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_1"));
   ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_2"));
 
-  ASSERT_TRUE(lifecycle_mgr_.shutdown(std_msec(2000), std_msec(2000)).empty());
+  ASSERT_TRUE(lifecycle_mgr_.shutdown(2000ms, 2000ms).empty());
   ASSERT_TRUE(lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED == lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_1") || lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN == lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_1"));
   ASSERT_TRUE(lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED == lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_2") || lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN == lifecycle_mgr_.get_managed_node_state("test_lifecycle_node_2"));
 


### PR DESCRIPTION
# PR Details
## Description

This PR refactors the `ros2_lifecycle_manager` package's unit tests to work with both Foxy and Humble. Sometime between Foxy and Humble, the `spin_until_future_complete()` function's behavior changed. In Humble, the function may not return even when the conditioned `std::future` is set. This seems to be an open bug (see ros2/rclcpp#1916).

The unit tests now use the implementation approach suggested in one of the [ROS 2 demos PRs](https://github.com/ros2/demos/pull/558/files#r871940510). Instead of running the unit tests in a new thread, we spin the executor in the new thread. The unit test assertions now run in the main thread.

## Related GitHub Issue

## Related Jira Key

Closes [CF-806](https://usdot-carma.atlassian.net/browse/CF-806)
[CF-793](https://usdot-carma.atlassian.net/browse/CF-793)

## Motivation and Context

Needed for porting `ros2_lifecycle_manager` package to ROS 2 Humble

## How Has This Been Tested?

Unit tests

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] All new and existing tests passed.


[CF-806]: https://usdot-carma.atlassian.net/browse/CF-806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CF-793]: https://usdot-carma.atlassian.net/browse/CF-793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ