### PR TITLE
Add Humble forward compatibility support for `rclcpp_lifecycle::LifecyclePublisher`s

### DIFF
--- a/carma_ros2_utils/CMakeLists.txt
+++ b/carma_ros2_utils/CMakeLists.txt
@@ -29,24 +29,39 @@ include_directories(
   include
 )
 
+# TODO(CAR-6017): Remove when we drop support for Foxy
+# rclcpp_lifecycle has breaking API changes starting with Humble
+if(("$ENV{ROS_DISTRO}" STREQUAL "foxy") OR ("$ENV{ROS_DISTRO}" STREQUAL "galactic"))
+  set(carma_ros2_utils_LIFECYCLE_PUBLISHER_INTERFACE_TYPE
+    rclcpp_lifecycle::LifecyclePublisherInterface
+  )
+else()
+  set(carma_ros2_utils_LIFECYCLE_PUBLISHER_INTERFACE_TYPE
+    rclcpp_lifecycle::ManagedEntityInterface
+  )
+endif()
+
+configure_file(
+  src/carma_lifecycle_node.hpp.in
+  carma_ros2_utils/carma_lifecycle_node.hpp
+)
+
 # Build
 ament_auto_add_library(${PROJECT_NAME} SHARED
   src/carma_lifecycle_node.cpp
 )
 
-# TODO(CAR-6017): Remove when we drop support for Foxy
-# rclcpp_lifecycle has breaking API changes starting with Humble
-if("$ENV{ROS_DISTRO}" STREQUAL "foxy")
-  target_compile_definitions(carma_ros2_utils
-    PUBLIC
-      ROS_DISTRO_FOXY
-  )
-elseif("$ENV{ROS_DISTRO}" STREQUAL "galactic")
-  target_compile_definitions(carma_ros2_utils
-    PUBLIC
-      ROS_DISTRO_GALACTIC
-  )
-endif()
+target_include_directories(${PROJECT_NAME}
+  PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
+)
+
+include(GNUInstallDirs)
+
+INSTALL(FILES ${PROJECT_BINARY_DIR}/carma_ros2_utils/carma_lifecycle_node.hpp
+  DESTINATION
+    ${CMAKE_INSTALL_INCLUDEDIR}/carma_ros2_utils
+)
 
 ament_auto_add_library(carma_ros2_utils_timers SHARED
   src/timers/testing/TestTimer.cpp

--- a/carma_ros2_utils/CMakeLists.txt
+++ b/carma_ros2_utils/CMakeLists.txt
@@ -29,11 +29,22 @@ include_directories(
   include
 )
 
+# Build
+ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/carma_lifecycle_node.cpp
+)
+
 # TODO(CAR-6017): Remove when we drop support for Foxy
+# rclcpp_lifecycle has breaking API changes starting with Humble
 if("$ENV{ROS_DISTRO}" STREQUAL "foxy")
   target_compile_definitions(carma_ros2_utils
     PUBLIC
       ROS_DISTRO_FOXY
+  )
+elseif("$ENV{ROS_DISTRO}" STREQUAL "galactic")
+  target_compile_definitions(carma_ros2_utils
+    PUBLIC
+      ROS_DISTRO_GALACTIC
   )
 endif()
 

--- a/carma_ros2_utils/CMakeLists.txt
+++ b/carma_ros2_utils/CMakeLists.txt
@@ -15,10 +15,12 @@ include_directories(
   include
 )
 
-# Build
-ament_auto_add_library(${PROJECT_NAME} SHARED
-  src/carma_lifecycle_node.cpp
-)
+if("$ENV{ROS_DISTRO}" STREQUAL "foxy")
+  target_compile_definitions(carma_ros2_utils
+    PUBLIC
+      ROS_DISTRO_FOXY
+  )
+endif()
 
 ament_auto_add_library(carma_ros2_utils_timers SHARED
   src/timers/testing/TestTimer.cpp

--- a/carma_ros2_utils/CMakeLists.txt
+++ b/carma_ros2_utils/CMakeLists.txt
@@ -29,6 +29,7 @@ include_directories(
   include
 )
 
+# TODO(CAR-6017): Remove when we drop support for Foxy
 if("$ENV{ROS_DISTRO}" STREQUAL "foxy")
   target_compile_definitions(carma_ros2_utils
     PUBLIC

--- a/carma_ros2_utils/CMakeLists.txt
+++ b/carma_ros2_utils/CMakeLists.txt
@@ -1,3 +1,17 @@
+# Copyright 2024 Leidos
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 cmake_minimum_required(VERSION 3.5)
 project(carma_ros2_utils)
 

--- a/carma_ros2_utils/include/carma_ros2_utils/carma_lifecycle_node.hpp
+++ b/carma_ros2_utils/include/carma_ros2_utils/carma_lifecycle_node.hpp
@@ -402,8 +402,9 @@ namespace carma_ros2_utils
     std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<carma_msgs::msg::SystemAlert>>
         system_alert_pub_;
 
-    // TODO(CAR-6017): Remove when we drop support for Foxy
-#ifdef ROS_DISTRO_FOXY
+    // TODO(CAR-6017): Remove when we transition to Humble
+    // LifecyclePublisherInterface was replaced with ManagedEntityInterface in Humble
+#if defined(ROS_DISTRO_FOXY) || defined(ROS_DISTRO_GALACTIC)
     //! A list of lifecycle publishers produced from this node whose lifetimes can be managed
     std::vector<std::shared_ptr<rclcpp_lifecycle::LifecyclePublisherInterface>> lifecycle_publishers_;
 #else

--- a/carma_ros2_utils/include/carma_ros2_utils/carma_lifecycle_node.hpp
+++ b/carma_ros2_utils/include/carma_ros2_utils/carma_lifecycle_node.hpp
@@ -402,10 +402,12 @@ namespace carma_ros2_utils
     std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<carma_msgs::msg::SystemAlert>>
         system_alert_pub_;
 
-    //! A list of lifecycle publishers produced from this node whose lifetimes can be managed
+    // TODO(CAR-6017): Remove when we drop support for Foxy
 #ifdef ROS_DISTRO_FOXY
+    //! A list of lifecycle publishers produced from this node whose lifetimes can be managed
     std::vector<std::shared_ptr<rclcpp_lifecycle::LifecyclePublisherInterface>> lifecycle_publishers_;
 #else
+    //! A list of lifecycle publishers produced from this node whose lifetimes can be managed
     std::vector<std::shared_ptr<rclcpp_lifecycle::ManagedEntityInterface>> lifecycle_publishers_;
 #endif
 

--- a/carma_ros2_utils/include/carma_ros2_utils/carma_lifecycle_node.hpp
+++ b/carma_ros2_utils/include/carma_ros2_utils/carma_lifecycle_node.hpp
@@ -17,15 +17,15 @@
 /**
  * This file is loosely based on the reference architecture developed by OSRF for Leidos located here
  * https://github.com/mjeronimo/carma2/blob/master/carma_utils/carma_utils/include/carma_utils/carma_lifecycle_node.hpp
- * 
+ *
  * That file has the following license and some code snippets from it may be present in this file as well and are under the same license.
- * 
+ *
  * Copyright 2021 Open Source Robotics Foundation, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -33,7 +33,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */ 
+ */
 
 #ifndef CARMA_ROS2_UTILS__CARMA_LIFECYCLE_NODE_HPP_
 #define CARMA_ROS2_UTILS__CARMA_LIFECYCLE_NODE_HPP_
@@ -70,17 +70,17 @@ namespace carma_ros2_utils
 
   /**
  * \brief The CarmaLifecycleNode provides default exception handling and SystemAlert handling for components in carma-platform.
- *        All new nodes in carma-platform are expected to be built off CarmaLifecycleNode and implemented as components. 
- * 
+ *        All new nodes in carma-platform are expected to be built off CarmaLifecycleNode and implemented as components.
+ *
  * Every function which uses callbacks (subscribers, publishers, services, timers) is wrapped in a try catch block
  * In the event an exception makes it to this class it will result in a SystemAlert message being published and the node shutting down.
  * NOTE: As the subscription/timer/service methods of the base LifeCycle node class are not virtual the override of these methods here
- *       will not properly handle polymorphism. Therefore try catches must be manually added when passing this object to a method which 
- *       takes a regular node to setup callbacks. 
- * 
+ *       will not properly handle polymorphism. Therefore try catches must be manually added when passing this object to a method which
+ *       takes a regular node to setup callbacks.
+ *
  * The user can add their own exception, alert, and shutdown handling using corresponding handler functions:
  *    handle_on_error, handle_on_system_alert, handle_on_shutdown
- * 
+ *
  * This class is thread safe
  */
   class CarmaLifecycleNode : public rclcpp_lifecycle::LifecycleNode
@@ -88,7 +88,7 @@ namespace carma_ros2_utils
   public:
     /**
    * \brief Constructor which is used by component loaders
-   * 
+   *
    * \param options The configurations options for this node
    */
     CARMA_ROS2_UTILS_PUBLIC
@@ -101,7 +101,7 @@ namespace carma_ros2_utils
 
     /**
    * \brief Overrides: See https://github.com/ros2/rclcpp/blob/foxy/rclcpp_lifecycle/include/rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp for their details
-   * NOTE: These methods are NOT meant to be used by extending classes. Instead the corresponding handle_<method> methods should be used 
+   * NOTE: These methods are NOT meant to be used by extending classes. Instead the corresponding handle_<method> methods should be used
    *       to ensure the full CARMALifecycleNode functionality is employed.
    */
     carma_ros2_utils::CallbackReturn on_configure(const rclcpp_lifecycle::State &prev_state) override;
@@ -114,20 +114,20 @@ namespace carma_ros2_utils
     /**
    * \brief Callback triggered when transitioning from UNCONFIGURED to INACTIVE due to the configure signal.
    *        This method should be overriden to load parameters and setup callbacks
-   * 
-   * \param state The previous state 
-   * 
-   * \return A callback success flag. If SUCCESS then the state will transition to INACTIVE. 
+   *
+   * \param state The previous state
+   *
+   * \return A callback success flag. If SUCCESS then the state will transition to INACTIVE.
    *        If FAILURE or ERROR occurs the state will transition to ErrorProcessing via the handle_on_error method
    */
     virtual carma_ros2_utils::CallbackReturn handle_on_configure(const rclcpp_lifecycle::State &prev_state);
     /**
    * \brief Callback triggered when transitioning from INACTIVE to ACTIVE due to the activate signal.
    *        This method should be overriden to set any states or callbacks that should only trigger in the ACTIVE state
-   * 
-   * \param state The previous state 
-   * 
-   * \return A callback success flag. If SUCCESS then the state will transition to ACTIVE. 
+   *
+   * \param state The previous state
+   *
+   * \return A callback success flag. If SUCCESS then the state will transition to ACTIVE.
    *        If FAILURE or ERROR occurs the state will transition to ErrorProcessing via the handle_on_error method
    */
     virtual carma_ros2_utils::CallbackReturn handle_on_activate(const rclcpp_lifecycle::State &prev_state);
@@ -135,12 +135,12 @@ namespace carma_ros2_utils
    * \brief Callback triggered when transitioning from ACTIVE to INACTIVE due to the deactivate signal.
    *        This method should be overriden to clear any runtime state data that would prevent reconfiguring of the node
    *        and or deactivate any timers/callbacks that should only trigger in the ACTIVE state
-   * 
-   *        NOTE: CarmaLifecycleNode will automatically deactivate publishers on this callback. 
-   * 
-   * \param state The previous state 
-   * 
-   * \return A callback success flag. If SUCCESS then the state will transition to INACTIVE. 
+   *
+   *        NOTE: CarmaLifecycleNode will automatically deactivate publishers on this callback.
+   *
+   * \param state The previous state
+   *
+   * \return A callback success flag. If SUCCESS then the state will transition to INACTIVE.
    *        If FAILURE or ERROR occurs the state will transition to ErrorProcessing via the handle_on_error method
    */
     virtual carma_ros2_utils::CallbackReturn handle_on_deactivate(const rclcpp_lifecycle::State &prev_state);
@@ -149,12 +149,12 @@ namespace carma_ros2_utils
    * \brief Callback triggered when transitioning from INACTIVE to UNCONFIGURED due to the cleanup signal.
    *        This method should be overriden to clear any state and memory allocation that occurred.
    *        When completed the node should be fully unconfigured.
-   * 
+   *
    *        NOTE: CarmaLifecycleNode will automatically deactivate publishers and clear timer pointers
-   * 
-   * \param state The previous state 
-   * 
-   * \return A callback success flag. If SUCCESS then the state will transition to UNCONFIGURED. 
+   *
+   * \param state The previous state
+   *
+   * \return A callback success flag. If SUCCESS then the state will transition to UNCONFIGURED.
    *        If FAILURE or ERROR occurs the state will transition to ErrorProcessing via the handle_on_error method
    */
     virtual carma_ros2_utils::CallbackReturn handle_on_cleanup(const rclcpp_lifecycle::State &prev_state);
@@ -162,12 +162,12 @@ namespace carma_ros2_utils
     /**
    * \brief Callback triggered when transitioning from any state to ErrorProcessing due to the error signal.
    *        This method should be overriden to add any exception handling logic.
-   * 
-   *        NOTE: CarmaLifecycleNode will automatically publish a FATAL SystemAlert before this is triggered. 
-   * 
-   * \param state The previous state 
-   * 
-   * \return A callback success flag. If SUCCESS then the state will transition to UNCONFIGURED. 
+   *
+   *        NOTE: CarmaLifecycleNode will automatically publish a FATAL SystemAlert before this is triggered.
+   *
+   * \param state The previous state
+   *
+   * \return A callback success flag. If SUCCESS then the state will transition to UNCONFIGURED.
    *        If FAILURE or ERROR occurs the state will transition to FINALIZED and the process will shutdown
    */
     virtual carma_ros2_utils::CallbackReturn handle_on_error(const rclcpp_lifecycle::State &prev_state, const std::string &exception_string);
@@ -175,18 +175,18 @@ namespace carma_ros2_utils
     /**
    * \brief Callback triggered when transitioning from any state to ShuttingDown due to the error shutdown.
    *        This method should be overriden to add any shutdown logic
-   * 
-   * 
-   * \param state The previous state 
-   * 
-   * \return A callback success flag. If SUCCESS then the state will transition to FINALIZED. 
+   *
+   *
+   * \param state The previous state
+   *
+   * \return A callback success flag. If SUCCESS then the state will transition to FINALIZED.
    *        If FAILURE or ERROR occurs the state will transition to FINALIZED and the process will shutdown
    */
     virtual carma_ros2_utils::CallbackReturn handle_on_shutdown(const rclcpp_lifecycle::State &prev_state);
 
     /**
    * \brief Convenience method to build a shared pointer from this object.
-   * 
+   *
    * \return A shared pointer which points to this object
    */
     std::shared_ptr<carma_ros2_utils::CarmaLifecycleNode> shared_from_this();
@@ -201,8 +201,8 @@ namespace carma_ros2_utils
     /**
      * \brief Override of parent method. See descriptive comments here:
      *  https://github.com/ros2/rclcpp/blob/4859c4e43576d0c6fe626679b2c2604a9a8b336c/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp#L230
-     * 
-     * NOTE: The function object passed to this method will be moved using std::move. 
+     *
+     * NOTE: The function object passed to this method will be moved using std::move.
      *       The user should therefore assume ownership of this function object has been relinquished
      */
     template <
@@ -238,11 +238,11 @@ namespace carma_ros2_utils
     /**
      * \brief Override of parent method. See descriptive comments here:
      *  https://github.com/ros2/rclcpp/blob/4859c4e43576d0c6fe626679b2c2604a9a8b336c/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp#L463
-     * 
-     * NOTE: The function object passed to this method will be moved using std::move. 
+     *
+     * NOTE: The function object passed to this method will be moved using std::move.
      *       The user should therefore assume ownership of this function object has been relinquished
-     * 
-     * NOTE: The returned callback handle is also cached inside CarmaLifecycleNode, so the user need not track it 
+     *
+     * NOTE: The returned callback handle is also cached inside CarmaLifecycleNode, so the user need not track it
      *       unless they intend to use it
      */
     rclcpp_lifecycle::LifecycleNode::OnSetParametersCallbackHandle::SharedPtr
@@ -253,7 +253,7 @@ namespace carma_ros2_utils
      * \brief Override of parent method. See descriptive comments here:
      *  https://github.com/ros2/rclcpp/blob/4859c4e43576d0c6fe626679b2c2604a9a8b336c/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp#L249
      *
-     * NOTE: The function object passed to this method will be moved using std::move. 
+     * NOTE: The function object passed to this method will be moved using std::move.
      *       The user should therefore assume ownership of this function object has been relinquished
      */
     template <typename DurationRepT = int64_t, typename DurationT = std::milli, typename CallbackT>
@@ -266,19 +266,19 @@ namespace carma_ros2_utils
 
     /**
      * \brief Method to create a timer whose lifecycle can be managed by this node.
-     *  
+     *
      *  NOTE: In foxy the LifecycleNode api is slightly out of sync with the node api so there is not a create_timer method there. We use rclcpp directly here
-     *  
+     *
      *  \param clock The underlying clock to use for the timer.
      *  \param period The period of trigger of the timer.
      *  \param callback The callback to execute on timer trigger
      *  \param group The callback group to use for processing the callback.
-     * 
+     *
      *  \return A pointer to an intialized timer. The timer will be cancled when this node transitions through a deactivate/cleanup sequence
      *
-     * NOTE: The function object passed to this method will be moved using std::move. 
+     * NOTE: The function object passed to this method will be moved using std::move.
      *       The user should therefore assume ownership of this function object has been relinquished
-     * 
+     *
      */
     template <typename CallbackT>
     typename rclcpp::TimerBase::SharedPtr
@@ -291,10 +291,10 @@ namespace carma_ros2_utils
     /**
      * \brief Override of rclcpp method. See descriptive comments here:
      *  https://github.com/ros2/rclcpp/blob/4859c4e43576d0c6fe626679b2c2604a9a8b336c/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp#L271
-     *  
+     *
      *  NOTE: In foxy the LifecycleNode api is slightly out of sync with the node api so there is not a create_service method there. We use rclcpp directly here
      *
-     * NOTE: The function object passed to this method will be moved using std::move. 
+     * NOTE: The function object passed to this method will be moved using std::move.
      *       The user should therefore assume ownership of this function object has been relinquished
      */
     template <typename ServiceT, typename CallbackT>
@@ -308,33 +308,33 @@ namespace carma_ros2_utils
     /**
      * \brief Override of parent method. See descriptive comments here:
      *  https://github.com/ros2/rclcpp/blob/d7804e1b3fd9676d302ec72f02c49ba04cbed5e6/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp#L260
-     * 
-     * VERY IMPORTANT NOTE: While the callback group default appears to be nullptr this is not actually the case. 
-     *                      On call the group will be set to the Reentrant CallbackGroup this->service_callback_group_ 
-     *                      This group is created explicitly for services to support a synchronous callback paradigm similar to ROS1. 
+     *
+     * VERY IMPORTANT NOTE: While the callback group default appears to be nullptr this is not actually the case.
+     *                      On call the group will be set to the Reentrant CallbackGroup this->service_callback_group_
+     *                      This group is created explicitly for services to support a synchronous callback paradigm similar to ROS1.
      *                      Care should be taken when changing this default group value.
      *                      If the user needs nullptr as the actual input they can call the parent method rclcpp_lifecycle::LifecycleNode::create_client
      */
     template <class ServiceT>
     typename rclcpp::Client<ServiceT>::SharedPtr
-    create_client(const std::string service_name, 
+    create_client(const std::string service_name,
         const rmw_qos_profile_t & qos_profile = rmw_qos_profile_services_default,
         rclcpp::CallbackGroup::SharedPtr group = nullptr);
 
     /**
      * \brief Helper method for setting parameters based on the input to a parameter callback as used by add_on_set_parameters_callback()
      *        This method will take a map of parameter name and the parameter variable (passed as reference) and set the parameter.
-     * 
+     *
      * NOTE: This method is templated and should be called once for each parameter type which needs to be set.
-     * 
+     *
      * \tparam T The type of the parameter to set. Must be one of the ROS supported parameter types. If not then this method will return an error.
      * \param update_targets A map of parameter names and the parameter variable (passed as reference) to set
-     * \param new_params The list of new parameters that provided by the input to a parameter callback. 
+     * \param new_params The list of new parameters that provided by the input to a parameter callback.
      *                   Parameters not listed in both the update_targets and new_params will be ignored.
-     * 
-     * \return boost::optional<std::string> A string containing the error description if a parameter could not be set. 
+     *
+     * \return boost::optional<std::string> A string containing the error description if a parameter could not be set.
      *         If boost::none then no error occurred
-     */ 
+     */
     template<typename T>
     boost::optional<std::string> update_params(const std::unordered_map<std::string, std::reference_wrapper<T>>& update_targets,
                    const std::vector< rclcpp::Parameter > & new_params);
@@ -342,17 +342,17 @@ namespace carma_ros2_utils
     /**
      * \brief Helper method for setting parameters based on the input to a parameter callback as used by add_on_set_parameters_callback()
      *        This method will take a map of parameter name and a setter function which will set the named parameter.
-     * 
+     *
      * NOTE: This method is templated and should be called once for each parameter type which needs to be set.
-     * 
+     *
      * \tparam T The type of the parameter to set. Must be one of the ROS supported parameter types. If not then this method will return an error.
      * \param update_targets A map of parameter names and a setter function which will set the named parameter. The setter function should return the old value;
-     * \param new_params The list of new parameters that provided by the input to a parameter callback. 
+     * \param new_params The list of new parameters that provided by the input to a parameter callback.
      *                   Parameters not listed in both the update_targets and new_params will be ignored.
-     * 
-     * \return boost::optional<std::string> A string containing the error description if a parameter could not be set. 
+     *
+     * \return boost::optional<std::string> A string containing the error description if a parameter could not be set.
      *         If boost::none then no error occurred
-     */ 
+     */
     template<typename T>
     boost::optional<std::string> update_params(const std::unordered_map<std::string, std::function<T(T)>>& update_targets,
                    const std::vector< rclcpp::Parameter > & new_params);
@@ -361,16 +361,16 @@ namespace carma_ros2_utils
     /**
    * \brief Helper method to handle exceptions which occurred in primary states.
    *        This is needed as the life cycle diagram described here https://design.ros2.org/articles/node_lifecycle.html
-   *        does not reflect current implementation where error handling is only handled by transition states. 
+   *        does not reflect current implementation where error handling is only handled by transition states.
    *        Current ROS2 Issue/PR: https://github.com/ros2/rclcpp/pull/1064
-   * 
+   *
    * \param e The exception to be handled. Defaults to runtime error, thrown in case error isn't specified.
    */
     void handle_primary_state_exception(const std::exception &e = std::runtime_error("Encountered Error"));
 
     /**
    * \brief Helper method to publish a system alert of type FATAL with the provided error string.
-   * 
+   *
    * \param alert_string The message description to send.
    */
     void send_error_alert_msg_for_string(const std::string &alert_string);
@@ -403,7 +403,11 @@ namespace carma_ros2_utils
         system_alert_pub_;
 
     //! A list of lifecycle publishers produced from this node whose lifetimes can be managed
+#ifdef ROS_DISTRO_FOXY
     std::vector<std::shared_ptr<rclcpp_lifecycle::LifecyclePublisherInterface>> lifecycle_publishers_;
+#else
+    std::vector<std::shared_ptr<rclcpp_lifecycle::ManagedEntityInterface>> lifecycle_publishers_;
+#endif
 
     //! A list of timers produced from this node whose lifetimes can be managed
     std::vector<std::shared_ptr<rclcpp::TimerBase>> timers_;

--- a/carma_ros2_utils/include/carma_ros2_utils/timers/ROSTimer.hpp
+++ b/carma_ros2_utils/include/carma_ros2_utils/timers/ROSTimer.hpp
@@ -15,7 +15,7 @@
  * the License.
  */
 #include <memory>
-#include "../carma_lifecycle_node.hpp"
+#include "carma_ros2_utils/carma_lifecycle_node.hpp"
 #include <rclcpp/timer.hpp>
 #include <rclcpp/time.hpp>
 #include "Timer.hpp"

--- a/carma_ros2_utils/include/carma_ros2_utils/timers/ROSTimerFactory.hpp
+++ b/carma_ros2_utils/include/carma_ros2_utils/timers/ROSTimerFactory.hpp
@@ -17,7 +17,7 @@
 #include <memory>
 #include <rclcpp/time.hpp>
 #include <rclcpp/timer.hpp>
-#include "../carma_lifecycle_node.hpp"
+#include "carma_ros2_utils/carma_lifecycle_node.hpp"
 #include "TimerFactory.hpp"
 #include "Timer.hpp"
 #include "ROSTimer.hpp"
@@ -38,7 +38,7 @@ public:
    * @brief Destructor
    */
   ~ROSTimerFactory();
-  
+
   void setCarmaLifecycleNode(std::weak_ptr<carma_ros2_utils::CarmaLifecycleNode> weak_node_pointer);
 
   //// Overrides

--- a/carma_ros2_utils/src/carma_lifecycle_node.cpp
+++ b/carma_ros2_utils/src/carma_lifecycle_node.cpp
@@ -17,15 +17,15 @@
 /**
  * This file is loosely based on the reference architecture developed by OSRF for Leidos located here
  * https://github.com/mjeronimo/carma2/blob/master/carma_utils/carma_utils/src/carma_lifecycle_node.cpp
- * 
+ *
  * That file has the following license and some code snippets from it may be present in this file as well and are under the same license.
- * 
+ *
  * Copyright 2021 Open Source Robotics Foundation, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -33,7 +33,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */ 
+ */
 
 #include "carma_ros2_utils/carma_lifecycle_node.hpp"
 
@@ -55,7 +55,7 @@ namespace carma_ros2_utils
 
     // NOTE: When creating this callback group it was not immediately clear if it should go in on_configure or the constructor
     //       Further usage of callback groups may elucidate this in the future
-    service_callback_group_ = get_node_base_interface()->create_callback_group(rclcpp::callback_group::CallbackGroupType::Reentrant);
+    service_callback_group_ = get_node_base_interface()->create_callback_group(rclcpp::CallbackGroupType::Reentrant);
   }
 
   CarmaLifecycleNode::~CarmaLifecycleNode()
@@ -141,8 +141,8 @@ namespace carma_ros2_utils
     }
 
     // Call the user error handling before clean up of the publishers to allow them to publish if needed
-    auto return_val = handle_on_error(prev_state, error_string); 
-    
+    auto return_val = handle_on_error(prev_state, error_string);
+
     cleanup_publishers();
     cleanup_timers();
     return  return_val;
@@ -178,7 +178,7 @@ namespace carma_ros2_utils
       RCLCPP_WARN_STREAM(get_logger(), "Sending SystemAlert likely failed as publisher is deactivated.");
     }
 
-    system_alert_pub_->publish(pub_msg); 
+    system_alert_pub_->publish(pub_msg);
   }
 
   void CarmaLifecycleNode::send_error_alert_msg_for_string(const std::string &alert_string)
@@ -196,7 +196,7 @@ namespace carma_ros2_utils
 
     rclcpp_lifecycle::State state_at_exception = get_current_state();
 
-    if (get_current_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE) // If the exception was caught in the ACTIVE state we can try to gracefully fail to on_error, by transitioning to deactivate and then throwning an exception
+    if (get_current_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE) // If the exception was caught in the ACTIVE state we can try to gracefully fail to on_error, by transitioning to deactivate and then throwing an exception
     {
       std::string error_msg = "Uncaught Exception from node: " + std::string(get_name()) + " exception: " + e.what() + " while in ACTIVE state.";
       caught_exception_ = error_msg;
@@ -270,7 +270,7 @@ namespace carma_ros2_utils
         {
           try
           {
-            
+
             return callback(params);
           }
           catch (const std::exception &e)
@@ -287,7 +287,7 @@ namespace carma_ros2_utils
         });
 
     param_callback_handles_.push_back(handle);
-    
+
     return handle;
   }
 

--- a/carma_ros2_utils/src/carma_lifecycle_node.hpp.in
+++ b/carma_ros2_utils/src/carma_lifecycle_node.hpp.in
@@ -14,6 +14,13 @@
  * the License.
  */
 
+/*
+ * TODO(CAR-6017): When we drop support for Foxy:
+ *   - replace CMake substitution strings with rclcpp::ManagedEntityInterface
+ *   - drop the .in filename suffix
+ *   - relocate file to include/ directory
+ */
+
 /**
  * This file is loosely based on the reference architecture developed by OSRF for Leidos located here
  * https://github.com/mjeronimo/carma2/blob/master/carma_utils/carma_utils/include/carma_utils/carma_lifecycle_node.hpp
@@ -402,15 +409,12 @@ namespace carma_ros2_utils
     std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<carma_msgs::msg::SystemAlert>>
         system_alert_pub_;
 
-    // TODO(CAR-6017): Remove when we transition to Humble
-    // LifecyclePublisherInterface was replaced with ManagedEntityInterface in Humble
-#if defined(ROS_DISTRO_FOXY) || defined(ROS_DISTRO_GALACTIC)
+    /*
+     * TODO(CAR-6017): Refactor when we transition to Humble.
+     * LifecyclePublisherInterface was replaced with ManagedEntityInterface in Humble
+     */
     //! A list of lifecycle publishers produced from this node whose lifetimes can be managed
-    std::vector<std::shared_ptr<rclcpp_lifecycle::LifecyclePublisherInterface>> lifecycle_publishers_;
-#else
-    //! A list of lifecycle publishers produced from this node whose lifetimes can be managed
-    std::vector<std::shared_ptr<rclcpp_lifecycle::ManagedEntityInterface>> lifecycle_publishers_;
-#endif
+    std::vector<std::shared_ptr<@carma_ros2_utils_LIFECYCLE_PUBLISHER_INTERFACE_TYPE@>> lifecycle_publishers_;
 
     //! A list of timers produced from this node whose lifetimes can be managed
     std::vector<std::shared_ptr<rclcpp::TimerBase>> timers_;
@@ -434,6 +438,6 @@ namespace carma_ros2_utils
 
 // Template functions cannot be linked unless the implementation is provided
 // Therefore include implementation to allow for template functions
-#include "internal/carma_lifecycle_node.tpp"
+#include "carma_ros2_utils/internal/carma_lifecycle_node.tpp"
 
 #endif // CARMA_ROS2_UTILS__CARMA_LIFECYCLE_NODE_HPP_"


### PR DESCRIPTION
# PR Details
## Description

This PR adds forward compatibility support for ROS Humble for the `rclcpp_lifecycle::LifecyclePublisher`. The `LifecyclePublisher` class uses a different base class in Humble than it does in Foxy. The base class from Foxy (`rclcpp_lifecycle::LifecyclePublisherInterface`) was removed between Foxy and Humble.

We still need to support both ROS releases for now, so we need a shim that can switch conditionally between the two APIs.

## Related GitHub Issue

## Related Jira Key

Closes [CF-811](https://usdot-carma.atlassian.net/browse/CF-811)
[CF-809](https://usdot-carma.atlassian.net/browse/CF-809)

## Motivation and Context

Needed for C1T development

## How Has This Been Tested?

Compiled with both Foxy and Humble. Humble has build errors, but those are unrelated to this change.

## Types of changes

- [x] New feature (non-breaking change that adds functionality)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.


[CF-811]: https://usdot-carma.atlassian.net/browse/CF-811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CF-809]: https://usdot-carma.atlassian.net/browse/CF-809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ