### PR TITLE
Update rclcpp::Duration API usage to support Foxy and Humble

### DIFF
--- a/carma_ros2_utils/include/carma_ros2_utils/timers/ROSTimer.hpp
+++ b/carma_ros2_utils/include/carma_ros2_utils/timers/ROSTimer.hpp
@@ -14,6 +14,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+#include <chrono>
 #include <memory>
 #include "carma_ros2_utils/carma_lifecycle_node.hpp"
 #include <rclcpp/timer.hpp>
@@ -32,7 +33,7 @@ class ROSTimer : public Timer
 {
   rclcpp::TimerBase::SharedPtr timer_;
   std::weak_ptr<carma_ros2_utils::CarmaLifecycleNode> weak_node_pointer_;
-  rclcpp::Duration duration_ = rclcpp::Duration(0);
+  rclcpp::Duration duration_ = rclcpp::Duration(std::chrono::nanoseconds{0});
   bool autostart_=true;
   std::function<void()> callback_;
 

--- a/carma_ros2_utils/include/carma_ros2_utils/timers/testing/TestTimer.hpp
+++ b/carma_ros2_utils/include/carma_ros2_utils/timers/testing/TestTimer.hpp
@@ -47,7 +47,7 @@ private:
   std::function<void()> callback_;
 
   rclcpp::Time start_time_ = rclcpp::Time(0);
-  rclcpp::Duration duration_ = rclcpp::Duration(0);
+  rclcpp::Duration duration_ = rclcpp::Duration(std::chrono::nanoseconds{0});
   carma_ros2_utils::timers::testing::TestClock::SharedPtr clock_; //! Interface used for accessing current time from rclcpp
   bool oneshot_ = false;
 

--- a/carma_ros2_utils/test/test_carma_lifecycle_exceptions.cpp
+++ b/carma_ros2_utils/test/test_carma_lifecycle_exceptions.cpp
@@ -31,7 +31,7 @@ namespace test_1
 {
     // This is a test node to support unit tests for the carma_lifecycle_node
     // NOTE: To make unit testing easier this node by default returns to unconfigured from ErrorProcessing unless an exception occurs in ErrorProcessing
-    //       This is different from the default CarmaLifecycleNode behavior which shuts the node down on exceptions 
+    //       This is different from the default CarmaLifecycleNode behavior which shuts the node down on exceptions
     class CarmaLifecycleNodeTest : public carma_ros2_utils::CarmaLifecycleNode
     {
     public:
@@ -235,7 +235,7 @@ TEST(CARMALifecycleNode, PrimaryStateErrors)
     // Evaluate timers
     auto exception_timer = node->create_timer(
         node->get_clock(),
-        rclcpp::Duration(10.0),
+        rclcpp::Duration(std::chrono::nanoseconds{10}),
         []()
         {
             throw std::runtime_error("Timer exception");
@@ -263,7 +263,7 @@ TEST(CARMALifecycleNode, PrimaryStateErrors)
         {
             throw std::runtime_error("Wall Timer exception");
         });
-    
+
     ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, node->get_current_state().id());
 
     // Trigger the callback
@@ -337,7 +337,7 @@ TEST(CARMALifecycleNode, PrimaryStateErrors)
     // Force the service callback to trigger the exception
     service->handle_request(header, request);
     ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED, node->get_current_state().id());
-    
+
 
 }
 

--- a/carma_ros2_utils/test/test_lifecycle_manager.cpp
+++ b/carma_ros2_utils/test/test_lifecycle_manager.cpp
@@ -28,91 +28,85 @@
 using std_msec = std::chrono::milliseconds;
 
 /**
- * This test is meant to exercise the CARMA Lifecycle Node with the standard flow of the lifecycle manager. 
- * To allow for callbacks to be processed the test makes use of a rather roundabout thread paradigm 
+ * This test is meant to exercise the CARMA Lifecycle Node with the standard flow of the lifecycle manager.
+ * To allow for callbacks to be processed the test makes use of a rather roundabout thread paradigm
  * Care should be taken to understand this code before trying to duplicate it in other test scenarios.
  * There may be better approaches such as the launch_testing framework.
- * 
- */ 
+ *
+ */
 TEST(LifecycleManagerTest, BasicTest)
 {
   // Test constructor
   auto node = std::make_shared<rclcpp::Node>("lifecycle_manager_test_node"); // Node to connect to ROS network
 
-  auto ret = rcutils_logging_set_logger_level(
-        node->get_logger().get_name(), RCUTILS_LOG_SEVERITY_DEBUG);
-  boost::ignore_unused(ret);
+  std::ignore = rcutils_logging_set_logger_level(
+      node->get_logger().get_name(), RCUTILS_LOG_SEVERITY_DEBUG);
 
-  std::promise<bool> promise_test_result; // Promise which will be used to spin the node until the test completes
-  std::shared_future<bool> future_test_result(promise_test_result.get_future()); // Future to check for spin
-
-  std::thread test_thread([&promise_test_result, node](){
-    
-    ros2_lifecycle_manager::Ros2LifecycleManager lifecycle_mgr_( // Construct lifecycle manager
-      node->get_node_base_interface(), 
-      node->get_node_graph_interface(), 
-      node->get_node_logging_interface(), 
+  ros2_lifecycle_manager::Ros2LifecycleManager lifecycle_mgr_( // Construct lifecycle manager
+      node->get_node_base_interface(),
+      node->get_node_graph_interface(),
+      node->get_node_logging_interface(),
       node->get_node_services_interface()
     );
 
-    // Test set_managed_nodes
-    lifecycle_mgr_.set_managed_nodes( { "test_carma_lifecycle_node_1", "test_carma_lifecycle_node_2" } );
-    
-    std::this_thread::sleep_for(std_msec(2000));
+  // Test set_managed_nodes
+  lifecycle_mgr_.set_managed_nodes( { "test_carma_lifecycle_node_1", "test_carma_lifecycle_node_2" } );
 
-    // Test get_managed_nodes
-    auto managed_nodes = lifecycle_mgr_.get_managed_nodes();
-    
-    ASSERT_EQ((uint8_t)2, managed_nodes.size());
-    ASSERT_EQ((uint8_t)0, managed_nodes[0].compare("test_carma_lifecycle_node_1"));
-    ASSERT_EQ((uint8_t)0, managed_nodes[1].compare("test_carma_lifecycle_node_2"));
-    
-    // Test get managed node states
-    ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, lifecycle_mgr_.get_managed_node_state("test_carma_lifecycle_node_1"));
-    ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, lifecycle_mgr_.get_managed_node_state("test_carma_lifecycle_node_2"));
-    ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN, lifecycle_mgr_.get_managed_node_state("unknown_node"));
+  std::this_thread::sleep_for(std_msec(2000));
 
-    // Test Configure
-    ASSERT_TRUE(lifecycle_mgr_.configure(std_msec(2000), std_msec(2000)).empty());
-    ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, lifecycle_mgr_.get_managed_node_state("test_carma_lifecycle_node_1"));
-    ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, lifecycle_mgr_.get_managed_node_state("test_carma_lifecycle_node_2"));
-
-    // Test Activate
-    ASSERT_TRUE(lifecycle_mgr_.activate(std_msec(2000), std_msec(2000)).empty());
-    ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE , lifecycle_mgr_.get_managed_node_state("test_carma_lifecycle_node_1"));
-    ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE , lifecycle_mgr_.get_managed_node_state("test_carma_lifecycle_node_2"));
-
-    // Test Deactivate
-    ASSERT_TRUE(lifecycle_mgr_.deactivate(std_msec(2000), std_msec(2000)).empty());
-    ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, lifecycle_mgr_.get_managed_node_state("test_carma_lifecycle_node_1"));
-    ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, lifecycle_mgr_.get_managed_node_state("test_carma_lifecycle_node_2"));
-
-    // Test cleanup
-    ASSERT_TRUE(lifecycle_mgr_.cleanup(std_msec(2000), std_msec(2000)).empty());
-    ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED , lifecycle_mgr_.get_managed_node_state("test_carma_lifecycle_node_1"));
-    ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED , lifecycle_mgr_.get_managed_node_state("test_carma_lifecycle_node_2"));
-
-    // Bring back to active then shutdown
-    ASSERT_TRUE(lifecycle_mgr_.configure(std_msec(2000), std_msec(2000)).empty());
-    ASSERT_TRUE(lifecycle_mgr_.activate(std_msec(2000), std_msec(2000)).empty());
-    ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE , lifecycle_mgr_.get_managed_node_state("test_carma_lifecycle_node_1"));
-    ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE , lifecycle_mgr_.get_managed_node_state("test_carma_lifecycle_node_2"));
-
-    ASSERT_TRUE(lifecycle_mgr_.shutdown(std_msec(2000), std_msec(2000)).empty());
-    ASSERT_TRUE(lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED  == lifecycle_mgr_.get_managed_node_state("test_carma_lifecycle_node_1")
-                || lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN  == lifecycle_mgr_.get_managed_node_state("test_carma_lifecycle_node_1"));
-    ASSERT_TRUE(lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED  == lifecycle_mgr_.get_managed_node_state("test_carma_lifecycle_node_2")
-                || lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN  == lifecycle_mgr_.get_managed_node_state("test_carma_lifecycle_node_2"));
-
-    promise_test_result.set_value(true);
-  });
+  // Test get_managed_nodes
+  auto managed_nodes = lifecycle_mgr_.get_managed_nodes();
 
   RCLCPP_INFO(node->get_logger(), "Spinning");
-  rclcpp::spin_until_future_complete(node, future_test_result);
 
-  test_thread.join(); // Ensure thread closes
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
 
-  
+  auto spin_future{std::async(std::launch::async, [&executor]
+                              { executor.spin(); })};
+
+  ASSERT_EQ((uint8_t)2, managed_nodes.size());
+  ASSERT_EQ((uint8_t)0, managed_nodes[0].compare("test_carma_lifecycle_node_1"));
+  ASSERT_EQ((uint8_t)0, managed_nodes[1].compare("test_carma_lifecycle_node_2"));
+
+  // Test get managed node states
+  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, lifecycle_mgr_.get_managed_node_state("test_carma_lifecycle_node_1"));
+  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, lifecycle_mgr_.get_managed_node_state("test_carma_lifecycle_node_2"));
+  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN, lifecycle_mgr_.get_managed_node_state("unknown_node"));
+
+  // Test Configure
+  ASSERT_TRUE(lifecycle_mgr_.configure(std_msec(2000), std_msec(2000)).empty());
+  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, lifecycle_mgr_.get_managed_node_state("test_carma_lifecycle_node_1"));
+  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, lifecycle_mgr_.get_managed_node_state("test_carma_lifecycle_node_2"));
+
+  // Test Activate
+  ASSERT_TRUE(lifecycle_mgr_.activate(std_msec(2000), std_msec(2000)).empty());
+  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE , lifecycle_mgr_.get_managed_node_state("test_carma_lifecycle_node_1"));
+  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE , lifecycle_mgr_.get_managed_node_state("test_carma_lifecycle_node_2"));
+
+  // Test Deactivate
+  ASSERT_TRUE(lifecycle_mgr_.deactivate(std_msec(2000), std_msec(2000)).empty());
+  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, lifecycle_mgr_.get_managed_node_state("test_carma_lifecycle_node_1"));
+  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, lifecycle_mgr_.get_managed_node_state("test_carma_lifecycle_node_2"));
+
+  // Test cleanup
+  ASSERT_TRUE(lifecycle_mgr_.cleanup(std_msec(2000), std_msec(2000)).empty());
+  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED , lifecycle_mgr_.get_managed_node_state("test_carma_lifecycle_node_1"));
+  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED , lifecycle_mgr_.get_managed_node_state("test_carma_lifecycle_node_2"));
+
+  // Bring back to active then shutdown
+  ASSERT_TRUE(lifecycle_mgr_.configure(std_msec(2000), std_msec(2000)).empty());
+  ASSERT_TRUE(lifecycle_mgr_.activate(std_msec(2000), std_msec(2000)).empty());
+  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE , lifecycle_mgr_.get_managed_node_state("test_carma_lifecycle_node_1"));
+  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE , lifecycle_mgr_.get_managed_node_state("test_carma_lifecycle_node_2"));
+
+  ASSERT_TRUE(lifecycle_mgr_.shutdown(std_msec(2000), std_msec(2000)).empty());
+  ASSERT_TRUE(lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED  == lifecycle_mgr_.get_managed_node_state("test_carma_lifecycle_node_1")
+              || lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN  == lifecycle_mgr_.get_managed_node_state("test_carma_lifecycle_node_1"));
+  ASSERT_TRUE(lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED  == lifecycle_mgr_.get_managed_node_state("test_carma_lifecycle_node_2")
+              || lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN  == lifecycle_mgr_.get_managed_node_state("test_carma_lifecycle_node_2"));
+
+  executor.cancel();
 }
 
 int main(int argc, char ** argv)
@@ -123,7 +117,7 @@ int main(int argc, char ** argv)
   rclcpp::init(argc, argv);
 
 
-  bool success = RUN_ALL_TESTS();  
+  bool success = RUN_ALL_TESTS();
 
   // shutdown ROS
   rclcpp::shutdown();

--- a/carma_ros2_utils/test/timers/TestingTimers.cpp
+++ b/carma_ros2_utils/test/timers/TestingTimers.cpp
@@ -19,6 +19,7 @@
 #include <carma_ros2_utils/timers/testing/TestTimer.hpp>
 #include <carma_ros2_utils/timers/testing/TestTimerFactory.hpp>
 #include <carma_ros2_utils/testing/TestHelpers.hpp>
+#include <chrono>
 
 
 namespace carma_ros2_utils
@@ -27,17 +28,20 @@ namespace timers
 {
 namespace testing
 {
-  
+
 TEST(TestingTimers, buildTimer)
 {
+  using std::chrono_literals::operator""s;
+  using std::chrono_literals::operator""ns;
+
   std::shared_ptr<carma_ros2_utils::timers::testing::TestTimerFactory> factory(new TestTimerFactory());  // Verify casting behavior
-  
+
   uint32_t id = 1;
   std::atomic<int> call_count(0);
 
   std::unique_ptr<carma_ros2_utils::timers::Timer> timer = factory->buildTimer(
-      id, rclcpp::Duration(1.0e9), [&]() -> void { call_count++; }, true);
-  
+      id, rclcpp::Duration(1s), [&]() -> void { call_count++; }, true);
+
 
   // Test setting and getting the timer id
   ASSERT_EQ(id, timer->getId());
@@ -59,7 +63,7 @@ TEST(TestingTimers, buildTimer)
   id = 3;
   call_count.store(0);
   timer = factory->buildTimer(
-      id, rclcpp::Duration(1.0), [&]() -> void { call_count++; }, true, false);
+      id, rclcpp::Duration(1ns), [&]() -> void { call_count++; }, true, false);
 
   ASSERT_EQ(0, call_count.load());
   factory->setNow(rclcpp::Time(3.2e9));
@@ -73,7 +77,7 @@ TEST(TestingTimers, buildTimer)
   id = 4;
   call_count.store(0);
   timer = factory->buildTimer(
-      id, rclcpp::Duration(1.0), [&]() -> void { call_count++; }, false, true);
+      id, rclcpp::Duration(1ns), [&]() -> void { call_count++; }, false, true);
 
   ASSERT_EQ(0, call_count.load());
   factory->setNow(rclcpp::Time(5.2e9));
@@ -92,7 +96,7 @@ TEST(TestingTimers, buildTimer)
   timer->start(); // Run start twice; This requires visual inspection of output to verify
 
   // // Verify duplicate initialization throw
-  ASSERT_THROW(timer->initializeTimer(rclcpp::Duration(1.0), [&](){}), std::invalid_argument);
+  ASSERT_THROW(timer->initializeTimer(rclcpp::Duration(1ns), [&](){}), std::invalid_argument);
 }
 
 }  // namespace testing


### PR DESCRIPTION
# PR Details
## Description

This PR updates all constructor references for `rclcpp::Duration`. The `rclcpp` version used in ROS Humble removed the `rclcpp::Duration` constructor for an `int64`, so we need to use an overload that's available on both Foxy and Humble.

## Related GitHub Issue

## Related Jira Key

Closes [CF-812](https://usdot-carma.atlassian.net/browse/CF-812)
[CF-809](https://usdot-carma.atlassian.net/browse/CF-809)

## Motivation and Context

Needed for Humble forwards compatibility

## How Has This Been Tested?

Built and unit test pass

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] All new and existing tests passed.


[CF-812]: https://usdot-carma.atlassian.net/browse/CF-812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CF-809]: https://usdot-carma.atlassian.net/browse/CF-809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ