### PR TITLE
Include last point in downsampling

### DIFF
--- a/carma_ros2_utils/include/carma_ros2_utils/containers/containers.hpp
+++ b/carma_ros2_utils/include/carma_ros2_utils/containers/containers.hpp
@@ -33,10 +33,13 @@ namespace containers
  * 
  * \param input The input vector to downsample
  * \param n The count of the elements to save
+ * \param include_last_point If true, append the last point
+          NOTE: default is true as this function is only used for trajectory generation 
+          and this keeps the lanelet's boundaries consistent no matter the downsample ratio
  * \return The downsampled vector
  */ 
 template <class T, class A = std::allocator<T>>
-std::vector<T, A> downsample_vector(const std::vector<T, A>& input, unsigned int n)
+std::vector<T, A> downsample_vector(const std::vector<T, A>& input, unsigned int n, bool include_last_point = true)
 {
   std::vector<T, A> output;
 
@@ -46,9 +49,19 @@ std::vector<T, A> downsample_vector(const std::vector<T, A>& input, unsigned int
 
   output.reserve((input.size() / n) + 1);
 
+  bool included_last_point = false;
   for (size_t i = 0; i < input.size(); i += n)
   {
     output.push_back(input[i]);
+    if (i == input.size() - 1)
+    {
+      included_last_point = true;
+    }
+  }
+
+  if (include_last_point && !included_last_point)
+  {
+    output.push_back(input.back());
   }
 
   return output;

--- a/carma_ros2_utils/test/containers/containers_test.cpp
+++ b/carma_ros2_utils/test/containers/containers_test.cpp
@@ -24,7 +24,7 @@ namespace containers
 TEST(containers_test, downsample_vector_test)
 {
   std::vector<int> vec = {0,1,2,3,4,5,6,7,8,9,10};
-  std::vector<int> out = downsample_vector(vec, 3);
+  std::vector<int> out = downsample_vector(vec, 3, false);
   
   ASSERT_EQ(4, out.size());
   ASSERT_EQ(0, out[0]);
@@ -36,6 +36,11 @@ TEST(containers_test, downsample_vector_test)
   ASSERT_EQ(0, out.size());
   out = downsample_vector<int>({}, 4);
   ASSERT_EQ(0, out.size());
+
+  out = downsample_vector(vec, 8, true);
+  ASSERT_EQ(0, out[0]);
+  ASSERT_EQ(7, out[1]);
+  ASSERT_EQ(10, out[2]);
 }
 
 int main(int argc, char ** argv)

--- a/carma_utils/include/carma_utils/containers/containers.h
+++ b/carma_utils/include/carma_utils/containers/containers.h
@@ -31,10 +31,13 @@ namespace containers
  * 
  * \param input The input vector to downsample
  * \param n The count of the elements to save
+ * \param include_last_point If true, append the last point
+          NOTE: default is true as this function is only used for trajectory generation 
+          and this keeps the lanelet's boundaries consistent no matter the downsample ratio
  * \return The downsampled vector
  */ 
 template <class T, class A = std::allocator<T>>
-std::vector<T, A> downsample_vector(const std::vector<T, A>& input, unsigned int n)
+std::vector<T, A> downsample_vector(const std::vector<T, A>& input, unsigned int n, bool include_last_point = true)
 {
   std::vector<T, A> output;
 
@@ -44,9 +47,19 @@ std::vector<T, A> downsample_vector(const std::vector<T, A>& input, unsigned int
 
   output.reserve((input.size() / n) + 1);
 
+  bool included_last_point = false;
   for (size_t i = 0; i < input.size(); i += n)
   {
     output.push_back(input[i]);
+    if (i == input.size() - 1)
+    {
+      included_last_point = true;
+    }
+  }
+
+  if (include_last_point && !included_last_point)
+  {
+    output.push_back(input.back());
   }
 
   return output;

--- a/carma_utils/test/carma_utils/containers/containers_test.cpp
+++ b/carma_utils/test/carma_utils/containers/containers_test.cpp
@@ -25,7 +25,7 @@ namespace containers
 TEST(containers_test, downsample_vector_test)
 {
   std::vector<int> vec = {0,1,2,3,4,5,6,7,8,9,10};
-  std::vector<int> out = downsample_vector(vec, 3);
+  std::vector<int> out = downsample_vector(vec, 3, false);
   
   ASSERT_EQ(4, out.size());
   ASSERT_EQ(0, out[0]);
@@ -37,6 +37,11 @@ TEST(containers_test, downsample_vector_test)
   ASSERT_EQ(0, out.size());
   out = downsample_vector<int>({}, 4);
   ASSERT_EQ(0, out.size());
+
+  out = downsample_vector(vec, 8, true);
+  ASSERT_EQ(0, out[0]);
+  ASSERT_EQ(7, out[1]);
+  ASSERT_EQ(10, out[2]);
 }
 }  // namespace containers
 }  // namespace carma_utils


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Original issue is described well in the Github Issue. 
Solution proposed here is to include the last point in the lanelet no matter the downsampling size, so that every lanelet's downsampling still has correct boundaries. 
This would also fix cases where if lanelet is too small to be downsampled, it would still return at least 2 trajectory points which should be enough to fit spline.
<!--- Describe your changes in detail -->

## Related GitHub Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/2343
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
https://usdot-carma.atlassian.net/browse/CAR-6038
<!-- e.g. CAR-123 -->

## Motivation and Context
Discovered during VRU use case validation testing data analysis
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
unit tested and integration testing on sim pc 1 in progress
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
