### PR TITLE
Motion computation ctrv angle fix

### DIFF
--- a/motion_predict/README.md
+++ b/motion_predict/README.md
@@ -3,10 +3,10 @@
 This library implements some basic motion prediction functions meant to support external object handling under the motion_predict namespace. Currently there are two motion models implements a Constant Velocity (CV) model and a Constant Turn-Rate and Velocity (CTRV) model. See the motion_predict.h and predict_ctrv.h files for the relevant interfaces.
 
 > [!NOTE]
-> Both motion models expect the objects' twist.linear data to be in a map frame as opposed to base_link frame commonly used in ROS.
+> Both motion models expect the objects' twist.linear data to be in a map frame as opposed to object's orientation frame commonly used in ROS.
 > For example:
 > - pose.pose.x and pose.pose.y expected to be the location of the object in a map frame
-> - twist.linear.x and twist.linear.y indicate the heading of the object in a map frame. Therefore, yaw value in CTRV or CV is the angle of the vector from this x,y.
+> - twist.linear.x and twist.linear.y indicate the heading of the object in a map frame. Therefore, yaw value in CTRV or CV is the angle of the vector from this x,y, which is respect to the map frame.
 >
 > This means that:
 > - pose.orientation is not meaningfully used except to pass it on. Usually this value aligns with the yaw calculated before, but can be different.

--- a/motion_predict/README.md
+++ b/motion_predict/README.md
@@ -3,7 +3,7 @@
 This library implements some basic motion prediction functions meant to support external object handling under the motion_predict namespace. Currently there are two motion models implements a Constant Velocity (CV) model and a Constant Turn-Rate and Velocity (CTRV) model. See the motion_predict.h and predict_ctrv.h files for the relevant interfaces.
 
 > [!NOTE]
-> Both motion models expect the objects' twist.linear data to be in a map frame as opposed to object's orientation frame commonly used in ROS.
+> Both motion models expect the objects' twist.linear data to be in a map frame as opposed to object's base_link commonly used in ROS https://www.ros.org/reps/rep-0105.html#base-link.
 > For example:
 > - pose.pose.x and pose.pose.y expected to be the location of the object in a map frame
 > - twist.linear.x and twist.linear.y indicate the heading of the object in a map frame. Therefore, yaw value in CTRV or CV is the angle of the vector from this x,y, which is respect to the map frame.

--- a/motion_predict/README.md
+++ b/motion_predict/README.md
@@ -2,14 +2,15 @@
 
 This library implements some basic motion prediction functions meant to support external object handling under the motion_predict namespace. Currently there are two motion models implements a Constant Velocity (CV) model and a Constant Turn-Rate and Velocity (CTRV) model. See the motion_predict.h and predict_ctrv.h files for the relevant interfaces.
 
-> **Note:** Both motion models expect the objects' twist data to be in map frame as opposed to base_link frame commonly used in ROS.
-For example:
-pose.pose.x and pose.pose.y expected to be the location of the object in the map frame
-twist.linear.x and twist.linear.y indicate the heading of the object in the map frame
-
-This means that
-pose.orientation is not meaningfully used except to pass it on.
-
-See open issue: https://github.com/usdot-fhwa-stol/carma-platform/issues/2401
+> [!NOTE]
+> Both motion models expect the objects' twist.linear data to be in a map frame as opposed to base_link frame commonly used in ROS.
+> For example:
+> - pose.pose.x and pose.pose.y expected to be the location of the object in a map frame
+> - twist.linear.x and twist.linear.y indicate the heading of the object in a map frame. Therefore, yaw value in CTRV or CV is the angle of the vector from this x,y.
+>
+> This means that:
+> - pose.orientation is not meaningfully used except to pass it on. Usually this value aligns with the yaw calculated before, but can be different.
+>
+> See this open issue for the reasoning and current limitation: https://github.com/usdot-fhwa-stol/carma-platform/issues/2401
 
 Link to detailed design on Confluence: https://usdot-carma.atlassian.net/l/c/e3U5DXZi

--- a/motion_predict/README.md
+++ b/motion_predict/README.md
@@ -1,5 +1,15 @@
 # motion_predict
 
-This library implements some basic motion prediction functions meant to support external object handling under the motion_predict namespace. Currently there are two motion models implements a Constant Velocity (CV) model and a Constant Turn-Rate and Velocity (CTRV) model. See the motion_predict.h and predict_ctrv.h files for the relevant interfaces. 
+This library implements some basic motion prediction functions meant to support external object handling under the motion_predict namespace. Currently there are two motion models implements a Constant Velocity (CV) model and a Constant Turn-Rate and Velocity (CTRV) model. See the motion_predict.h and predict_ctrv.h files for the relevant interfaces.
+
+> **Note:** Both motion models expect the objects' twist data to be in map frame as opposed to base_link frame commonly used in ROS.
+For example:
+pose.pose.x and pose.pose.y expected to be the location of the object in the map frame
+twist.linear.x and twist.linear.y indicate the heading of the object in the map frame
+
+This means that
+pose.orientation is not meaningfully used except to pass it on.
+
+See open issue: https://github.com/usdot-fhwa-stol/carma-platform/issues/2401
 
 Link to detailed design on Confluence: https://usdot-carma.atlassian.net/l/c/e3U5DXZi

--- a/motion_predict/include/motion_predict/motion_predict.hpp
+++ b/motion_predict/include/motion_predict/motion_predict.hpp
@@ -42,34 +42,29 @@ namespace cv{
     \param  pose is position and orientation (m).
     \param  twist is velocity (m/s).
     \param  delta_t time predicted into the future (sec).
-    \note twist.linear vector is expected to be in the map frame and used as the yaw for future prediction.
-          pose.orientation is not meaningfully used at the moment except passing it on.
+    \note pose and twist are expected in the map frame.
     */
     carma_perception_msgs::msg::PredictedState predictState(const geometry_msgs::msg::Pose& pose, const geometry_msgs::msg::Twist& twist,const double delta_t);
 
     /*!
     \brief  externalPredict populates motion prediction with future pose and velocity.
-    \param  obj external object.
+    \param  obj external object, whose pose and twist are expected in map frame
     \param  delta_t prediciton time into the future (sec)
     \param  ax acceleration noise along x-axis (m^2/s^4)
     \param  ay acceleration noise along y-axis (m^2/s^4)
     \param  process_noise_max is the maximum process noise of the system
-    \note twist.linear vector is expected to be in the map frame and used as the yaw for future prediction.
-        pose.orientation is not meaningfully used at the moment except passing it on.
     */
     carma_perception_msgs::msg::PredictedState externalPredict(const carma_perception_msgs::msg::ExternalObject &obj,const double delta_t,const double ax,const double ay,const double process_noise_max);
 
     /*!
     \brief  externalPeriod populates sequence of predicted motion of the object.
-    \param  obj external object.
+    \param  obj external object, whose pose and twist are expected in map frame
     \param  delta_t prediciton time into the future (sec)
     \param  period sequence/time steps (sec)
     \param  ax acceleration noise along x-axis (m^2/s^4)
     \param  ay acceleration noise along y-axis (m^2/s^4)
     \param  process_noise_max is the maximum process noise of the system
     \param  confidence_drop_rate rate of drop in confidence with time
-    \note twist.linear vector is expected to be in the map frame and used as the yaw for future prediction.
-        pose.orientation is not meaningfully used at the moment except passing it on.
     */
     std::vector<carma_perception_msgs::msg::PredictedState> predictPeriod(const carma_perception_msgs::msg::ExternalObject& obj, const double delta_t, const double period,const double ax,const double ay ,const double process_noise_max,const double confidence_drop_rate);
 

--- a/motion_predict/include/motion_predict/motion_predict.hpp
+++ b/motion_predict/include/motion_predict/motion_predict.hpp
@@ -70,11 +70,9 @@ namespace cv{
 
     /*!
     \brief  Mapping is used to map input range to an output range of different bandwidth.
-    \param  obj predicted object
+    \param  obj predicted object whose pose and twist are expected in map frame
     \param  delta_t time predicted into the future (sec)
     \param  confidence_drop_rate rate of drop in confidence with time
-    \note twist.linear vector is expected to be in the map frame and used as the yaw for future prediction.
-        pose.orientation is not meaningfully used at the moment except passing it on.
     */
     carma_perception_msgs::msg::PredictedState predictStep(const carma_perception_msgs::msg::PredictedState& obj, const double delta_t, const double confidence_drop_rate);
 

--- a/motion_predict/include/motion_predict/motion_predict.hpp
+++ b/motion_predict/include/motion_predict/motion_predict.hpp
@@ -35,7 +35,6 @@ namespace cv{
     \param  input is the current value of the process noise.
     \param  process_noise_max is the maxium process noise of the system
     */
-
     double Mapping(const double input,const double process_noise_max);
 
     /*!
@@ -43,8 +42,9 @@ namespace cv{
     \param  pose is position and orientation (m).
     \param  twist is velocity (m/s).
     \param  delta_t time predicted into the future (sec).
+    \note twist.linear vector is expected to be in the map frame and used as the yaw for future prediction.
+          pose.orientation is not meaningfully used at the moment except passing it on.
     */
-
     carma_perception_msgs::msg::PredictedState predictState(const geometry_msgs::msg::Pose& pose, const geometry_msgs::msg::Twist& twist,const double delta_t);
 
     /*!
@@ -54,8 +54,9 @@ namespace cv{
     \param  ax acceleration noise along x-axis (m^2/s^4)
     \param  ay acceleration noise along y-axis (m^2/s^4)
     \param  process_noise_max is the maximum process noise of the system
+    \note twist.linear vector is expected to be in the map frame and used as the yaw for future prediction.
+        pose.orientation is not meaningfully used at the moment except passing it on.
     */
-
     carma_perception_msgs::msg::PredictedState externalPredict(const carma_perception_msgs::msg::ExternalObject &obj,const double delta_t,const double ax,const double ay,const double process_noise_max);
 
     /*!
@@ -67,8 +68,9 @@ namespace cv{
     \param  ay acceleration noise along y-axis (m^2/s^4)
     \param  process_noise_max is the maximum process noise of the system
     \param  confidence_drop_rate rate of drop in confidence with time
+    \note twist.linear vector is expected to be in the map frame and used as the yaw for future prediction.
+        pose.orientation is not meaningfully used at the moment except passing it on.
     */
-
     std::vector<carma_perception_msgs::msg::PredictedState> predictPeriod(const carma_perception_msgs::msg::ExternalObject& obj, const double delta_t, const double period,const double ax,const double ay ,const double process_noise_max,const double confidence_drop_rate);
 
     /*!
@@ -76,8 +78,9 @@ namespace cv{
     \param  obj predicted object
     \param  delta_t time predicted into the future (sec)
     \param  confidence_drop_rate rate of drop in confidence with time
+    \note twist.linear vector is expected to be in the map frame and used as the yaw for future prediction.
+        pose.orientation is not meaningfully used at the moment except passing it on.
     */
-
     carma_perception_msgs::msg::PredictedState predictStep(const carma_perception_msgs::msg::PredictedState& obj, const double delta_t, const double confidence_drop_rate);
 
     /*Constant for conversion from seconds to nanoseconds*/

--- a/motion_predict/include/motion_predict/predict_ctrv.hpp
+++ b/motion_predict/include/motion_predict/predict_ctrv.hpp
@@ -44,8 +44,6 @@ std::vector<carma_perception_msgs::msg::PredictedState> predictPeriod(const carm
  * \param  obj external object whose twist and pose are expected in map frame
  * \param  delta_t prediction time into the future in seconds
  * \param  process_noise_max is the maximum process noise of the system
- * \note twist.linear vector is expected to be in the map frame and used as the yaw for future prediction.
- *       pose.orientation is not meaningfully used at the moment except passing it on.
  * \return The predicted state of the external object at time t + delta_t
  */
 

--- a/motion_predict/include/motion_predict/predict_ctrv.hpp
+++ b/motion_predict/include/motion_predict/predict_ctrv.hpp
@@ -32,7 +32,8 @@ namespace ctrv
  * \param  delta_t prediction time step size in seconds
  * \param  period The total prediction period in seconds
  * \param  process_noise_max is the maximum process noise of the system
- *
+ * \note twist.linear vector is expected to be in the map frame and used as the yaw for future prediction.
+ *       pose.orientation is not meaningfully used at the moment except passing it on.
  * \return The predicted state of the external object at time t + delta_t
  */
 std::vector<carma_perception_msgs::msg::PredictedState> predictPeriod(const carma_perception_msgs::msg::ExternalObject& obj, const double delta_t,
@@ -45,7 +46,8 @@ std::vector<carma_perception_msgs::msg::PredictedState> predictPeriod(const carm
  * \param  obj external object.
  * \param  delta_t prediction time into the future in seconds
  * \param  process_noise_max is the maximum process noise of the system
- *
+ * \note twist.linear vector is expected to be in the map frame and used as the yaw for future prediction.
+ *       pose.orientation is not meaningfully used at the moment except passing it on.
  * \return The predicted state of the external object at time t + delta_t
  */
 
@@ -59,7 +61,8 @@ carma_perception_msgs::msg::PredictedState predictStep(const carma_perception_ms
  * \param  obj previous prediction object.
  * \param  delta_t prediction time into the future in seconds
  * \param  process_noise_max is the maximum process noise of the system
- *
+ * \note twist.linear vector is expected to be in the map frame and used as the yaw for future prediction.
+ *       pose.orientation is not meaningfully used at the moment except passing it on.
  * \return The predicted state of the external object at time t + delta_t
  */
 

--- a/motion_predict/include/motion_predict/predict_ctrv.hpp
+++ b/motion_predict/include/motion_predict/predict_ctrv.hpp
@@ -28,12 +28,10 @@ namespace ctrv
  * \brief Generates a set of motion predictions seperated by the given time step size for the given period.
  *        Predictions are made using a CTRV motion model.
  *
- * \param  obj external object to predict
+ * \param  obj external object to predict whose twist and pose are expected in map frame
  * \param  delta_t prediction time step size in seconds
  * \param  period The total prediction period in seconds
  * \param  process_noise_max is the maximum process noise of the system
- * \note twist.linear vector is expected to be in the map frame and used as the yaw for future prediction.
- *       pose.orientation is not meaningfully used at the moment except passing it on.
  * \return The predicted state of the external object at time t + delta_t
  */
 std::vector<carma_perception_msgs::msg::PredictedState> predictPeriod(const carma_perception_msgs::msg::ExternalObject& obj, const double delta_t,
@@ -43,7 +41,7 @@ std::vector<carma_perception_msgs::msg::PredictedState> predictPeriod(const carm
  * \brief predictStep populates motion prediction with future pose and velocity.
  *     The predicted motion is created using a CTRV motion model
  *
- * \param  obj external object.
+ * \param  obj external object whose twist and pose are expected in map frame
  * \param  delta_t prediction time into the future in seconds
  * \param  process_noise_max is the maximum process noise of the system
  * \note twist.linear vector is expected to be in the map frame and used as the yaw for future prediction.
@@ -58,11 +56,9 @@ carma_perception_msgs::msg::PredictedState predictStep(const carma_perception_ms
  * \brief predictStep populates motion prediction with future pose and velocity.
  *     The predicted motion is created using a CTRV motion model.
  *
- * \param  obj previous prediction object.
+ * \param  obj previous prediction object whose twist and pose are expected in map frame
  * \param  delta_t prediction time into the future in seconds
  * \param  process_noise_max is the maximum process noise of the system
- * \note twist.linear vector is expected to be in the map frame and used as the yaw for future prediction.
- *       pose.orientation is not meaningfully used at the moment except passing it on.
  * \return The predicted state of the external object at time t + delta_t
  */
 

--- a/motion_predict/src/motion_predict.cpp
+++ b/motion_predict/src/motion_predict.cpp
@@ -39,6 +39,9 @@ carma_perception_msgs::msg::PredictedState predictState(const geometry_msgs::msg
 
   x(0)=pose.position.x; // Position X
   x(1)=pose.position.y; // Position Y
+
+  // TODO: Need a logic here to possible detect whether if twist.linear.x,y
+  // is in map frame. https://github.com/usdot-fhwa-stol/carma-platform/issues/2407
   x(2)=twist.linear.x; // Linear Velocity X
   x(3)=twist.linear.y; // Linear Velocity Y
 

--- a/motion_predict/src/motion_predict.cpp
+++ b/motion_predict/src/motion_predict.cpp
@@ -40,7 +40,7 @@ carma_perception_msgs::msg::PredictedState predictState(const geometry_msgs::msg
   x(0)=pose.position.x; // Position X
   x(1)=pose.position.y; // Position Y
 
-  // Need a logic here to possible detect whether if twist.linear.x,y
+  // TODO: Need a logic here to possible detect whether if twist.linear.x,y
   // is in map frame. https://github.com/usdot-fhwa-stol/carma-platform/issues/2407
   x(2)=twist.linear.x; // Linear Velocity X
   x(3)=twist.linear.y; // Linear Velocity Y

--- a/motion_predict/src/motion_predict.cpp
+++ b/motion_predict/src/motion_predict.cpp
@@ -40,7 +40,7 @@ carma_perception_msgs::msg::PredictedState predictState(const geometry_msgs::msg
   x(0)=pose.position.x; // Position X
   x(1)=pose.position.y; // Position Y
 
-  // TODO: Need a logic here to possible detect whether if twist.linear.x,y
+  // Need a logic here to possible detect whether if twist.linear.x,y
   // is in map frame. https://github.com/usdot-fhwa-stol/carma-platform/issues/2407
   x(2)=twist.linear.x; // Linear Velocity X
   x(3)=twist.linear.y; // Linear Velocity Y

--- a/motion_predict/src/predict_ctrv.cpp
+++ b/motion_predict/src/predict_ctrv.cpp
@@ -61,10 +61,13 @@ CTRV_State buildCTRVState(const geometry_msgs::msg::Pose& pose, const geometry_m
   CTRV_State state;
   state.x = pose.position.x;
   state.y = pose.position.y;
-  state.yaw = std::get<0>(vel_angle_and_mag); // TODO: currently, object's linear velocity is already in map frame.
-                                              // https://github.com/usdot-fhwa-stol/carma-platform/issues/2401
+  state.yaw = std::get<0>(vel_angle_and_mag); // Currently, object's linear velocity is already in map frame.
+                                              // Orientation of the object cannot be trusted for objects 
+                                              // as it could be drifting sideways while facing other direction
+                              
   //    rpy[2] + std::get<0>(vel_angle_and_mag);  // The yaw is relative to the velocity vector so take the heading and
   //                                              // add it to the angle of the velocity vector in the local frame
+  // Replace with logic above if this issue is decided: // https://github.com/usdot-fhwa-stol/carma-platform/issues/2401
   state.v = std::get<1>(vel_angle_and_mag);
   state.yaw_rate = twist.angular.z;
 

--- a/motion_predict/src/predict_ctrv.cpp
+++ b/motion_predict/src/predict_ctrv.cpp
@@ -56,15 +56,17 @@ CTRV_State buildCTRVState(const geometry_msgs::msg::Pose& pose, const geometry_m
   Eigen::Quaternionf e_quat(quat.w, quat.x, quat.y, quat.z);
   Eigen::Vector3f rpy = e_quat.toRotationMatrix().eulerAngles(0, 1, 2);
 
+  // TODO: Need a logic here to possible detect whether if twist.linear.x,y
+  // is in map frame. https://github.com/usdot-fhwa-stol/carma-platform/issues/2407
   auto vel_angle_and_mag = localVelOrientationAndMagnitude(twist.linear.x, twist.linear.y);
 
   CTRV_State state;
   state.x = pose.position.x;
   state.y = pose.position.y;
   state.yaw = std::get<0>(vel_angle_and_mag); // Currently, object's linear velocity is already in map frame.
-                                              // Orientation of the object cannot be trusted for objects 
+                                              // Orientation of the object cannot be trusted for objects
                                               // as it could be drifting sideways while facing other direction
-                              
+
   //    rpy[2] + std::get<0>(vel_angle_and_mag);  // The yaw is relative to the velocity vector so take the heading and
   //                                              // add it to the angle of the velocity vector in the local frame
   // Replace with logic above if this issue is decided: // https://github.com/usdot-fhwa-stol/carma-platform/issues/2401

--- a/motion_predict/src/predict_ctrv.cpp
+++ b/motion_predict/src/predict_ctrv.cpp
@@ -52,7 +52,7 @@ std::tuple<double, double> localVelOrientationAndMagnitude(const double v_x, con
 
 CTRV_State buildCTRVState(const geometry_msgs::msg::Pose& pose, const geometry_msgs::msg::Twist& twist)
 {
-  // Need a logic here to possible detect whether if twist.linear.x,y
+  // TODO: Need a logic here to possible detect whether if twist.linear.x,y
   // is in map frame. https://github.com/usdot-fhwa-stol/carma-platform/issues/2407
   auto vel_angle_and_mag = localVelOrientationAndMagnitude(twist.linear.x, twist.linear.y);
 
@@ -61,14 +61,10 @@ CTRV_State buildCTRVState(const geometry_msgs::msg::Pose& pose, const geometry_m
   state.y = pose.position.y;
   state.yaw = std::get<0>(vel_angle_and_mag); // Currently, object's linear velocity is already in map frame.
                                               // Orientation of the object cannot be trusted for objects
-                                              // as it could be drifting sideways while facing other direction
+                                              // as it could be drifting sideways while facing other direction.
+                                              // This may not be what the user expect, and below issue tracks it.
+                                              // https://github.com/usdot-fhwa-stol/carma-platform/issues/2401
 
-  // geometry_msgs::msg::Quaternion quat = pose.orientation;
-  // Eigen::Quaternionf e_quat(quat.w, quat.x, quat.y, quat.z);
-  // Eigen::Vector3f rpy = e_quat.toRotationMatrix().eulerAngles(0, 1, 2);
-  //    rpy[2] + std::get<0>(vel_angle_and_mag);  // The yaw is relative to the velocity vector so take the heading and
-  //                                              // add it to the angle of the velocity vector in the local frame
-  // Replace with logic above if this issue is decided: // https://github.com/usdot-fhwa-stol/carma-platform/issues/2401
   state.v = std::get<1>(vel_angle_and_mag);
   state.yaw_rate = twist.angular.z;
 
@@ -87,22 +83,8 @@ carma_perception_msgs::msg::PredictedState buildPredictionFromCTRVState(const CT
 
   // Map orientation
   pobj.predicted_position.orientation = original_pose.orientation;
-  //  Eigen::Quaternionf original_quat(original_pose.orientation.w, original_pose.orientation.x,
-  //                                   original_pose.orientation.y, original_pose.orientation.z);
-  //  Eigen::Vector3f original_rpy = original_quat.toRotationMatrix().eulerAngles(0, 1, 2);
-  //
-  //  auto vel_angle_and_mag = localVelOrientationAndMagnitude(original_twist.linear.x, original_twist.linear.y);
-  //
-  //  Eigen::Quaternionf final_quat;
-  //  final_quat = Eigen::AngleAxisf(original_rpy[0], Eigen::Vector3f::UnitX()) *
-  //               Eigen::AngleAxisf(original_rpy[1], Eigen::Vector3f::UnitY()) *
-  //               Eigen::AngleAxisf(state.yaw - std::get<0>(vel_angle_and_mag), Eigen::Vector3f::UnitZ());
-  //
-  //  pobj.predicted_position.orientation.x = final_quat.x();
-  //  pobj.predicted_position.orientation.y = final_quat.y();
-  //  pobj.predicted_position.orientation.z = final_quat.z();
-  //  pobj.predicted_position.orientation.w = final_quat.w();
-  //  Replace with logic above if this issue is decided: // https://github.com/usdot-fhwa-stol/carma-platform/issues/2401
+  // TODO: Take another look at orientation calculation after addressing this:
+  // https://github.com/usdot-fhwa-stol/carma-platform/issues/2401
 
   // Map twist
   // Constant velocity model means twist remains unchanged

--- a/motion_predict/src/predict_ctrv.cpp
+++ b/motion_predict/src/predict_ctrv.cpp
@@ -45,7 +45,7 @@ std::tuple<double, double> localVelOrientationAndMagnitude(const double v_x, con
   }
   else
   {
-    local_v_orientation = asin(v_y / v_mag);
+    local_v_orientation = atan2(v_y, v_x);
   }
   return std::make_tuple(local_v_orientation, v_mag);
 }
@@ -61,9 +61,10 @@ CTRV_State buildCTRVState(const geometry_msgs::msg::Pose& pose, const geometry_m
   CTRV_State state;
   state.x = pose.position.x;
   state.y = pose.position.y;
-  state.yaw =
-      rpy[2] + std::get<0>(vel_angle_and_mag);  // The yaw is relative to the velocity vector so take the heading and
-                                                // add it to the angle of the velocity vector in the local frame
+  state.yaw = std::get<0>(vel_angle_and_mag); // TODO: currently, object's linear velocity is already in map frame.
+                                              // https://github.com/usdot-fhwa-stol/carma-platform/issues/2401
+  //    rpy[2] + std::get<0>(vel_angle_and_mag);  // The yaw is relative to the velocity vector so take the heading and
+  //                                              // add it to the angle of the velocity vector in the local frame
   state.v = std::get<1>(vel_angle_and_mag);
   state.yaw_rate = twist.angular.z;
 
@@ -124,7 +125,7 @@ CTRV_State CTRVPredict(const CTRV_State& state, const double delta_t)
   double sin_yaw = sin(state.yaw);
   double cos_yaw = cos(state.yaw);
   double wT = state.yaw_rate * delta_t;
-  
+
   next_state.x = state.x + v_w * (sin(state.yaw + wT) - sin_yaw);
   next_state.y = state.y + v_w * (cos_yaw - cos(state.yaw + wT));
   next_state.yaw = state.yaw + wT;

--- a/motion_predict/src/predict_ctrv.cpp
+++ b/motion_predict/src/predict_ctrv.cpp
@@ -52,10 +52,6 @@ std::tuple<double, double> localVelOrientationAndMagnitude(const double v_x, con
 
 CTRV_State buildCTRVState(const geometry_msgs::msg::Pose& pose, const geometry_msgs::msg::Twist& twist)
 {
-  geometry_msgs::msg::Quaternion quat = pose.orientation;
-  Eigen::Quaternionf e_quat(quat.w, quat.x, quat.y, quat.z);
-  Eigen::Vector3f rpy = e_quat.toRotationMatrix().eulerAngles(0, 1, 2);
-
   // TODO: Need a logic here to possible detect whether if twist.linear.x,y
   // is in map frame. https://github.com/usdot-fhwa-stol/carma-platform/issues/2407
   auto vel_angle_and_mag = localVelOrientationAndMagnitude(twist.linear.x, twist.linear.y);
@@ -67,6 +63,9 @@ CTRV_State buildCTRVState(const geometry_msgs::msg::Pose& pose, const geometry_m
                                               // Orientation of the object cannot be trusted for objects
                                               // as it could be drifting sideways while facing other direction
 
+  // geometry_msgs::msg::Quaternion quat = pose.orientation;
+  // Eigen::Quaternionf e_quat(quat.w, quat.x, quat.y, quat.z);
+  // Eigen::Vector3f rpy = e_quat.toRotationMatrix().eulerAngles(0, 1, 2);
   //    rpy[2] + std::get<0>(vel_angle_and_mag);  // The yaw is relative to the velocity vector so take the heading and
   //                                              // add it to the angle of the velocity vector in the local frame
   // Replace with logic above if this issue is decided: // https://github.com/usdot-fhwa-stol/carma-platform/issues/2401
@@ -87,21 +86,23 @@ carma_perception_msgs::msg::PredictedState buildPredictionFromCTRVState(const CT
   pobj.predicted_position.position.z = original_pose.position.z;
 
   // Map orientation
-  Eigen::Quaternionf original_quat(original_pose.orientation.w, original_pose.orientation.x,
-                                   original_pose.orientation.y, original_pose.orientation.z);
-  Eigen::Vector3f original_rpy = original_quat.toRotationMatrix().eulerAngles(0, 1, 2);
-
-  auto vel_angle_and_mag = localVelOrientationAndMagnitude(original_twist.linear.x, original_twist.linear.y);
-
-  Eigen::Quaternionf final_quat;
-  final_quat = Eigen::AngleAxisf(original_rpy[0], Eigen::Vector3f::UnitX()) *
-               Eigen::AngleAxisf(original_rpy[1], Eigen::Vector3f::UnitY()) *
-               Eigen::AngleAxisf(state.yaw - std::get<0>(vel_angle_and_mag), Eigen::Vector3f::UnitZ());
-
-  pobj.predicted_position.orientation.x = final_quat.x();
-  pobj.predicted_position.orientation.y = final_quat.y();
-  pobj.predicted_position.orientation.z = final_quat.z();
-  pobj.predicted_position.orientation.w = final_quat.w();
+  pobj.predicted_position.orientation = original_pose.orientation;
+  //  Eigen::Quaternionf original_quat(original_pose.orientation.w, original_pose.orientation.x,
+  //                                   original_pose.orientation.y, original_pose.orientation.z);
+  //  Eigen::Vector3f original_rpy = original_quat.toRotationMatrix().eulerAngles(0, 1, 2);
+  //
+  //  auto vel_angle_and_mag = localVelOrientationAndMagnitude(original_twist.linear.x, original_twist.linear.y);
+  //
+  //  Eigen::Quaternionf final_quat;
+  //  final_quat = Eigen::AngleAxisf(original_rpy[0], Eigen::Vector3f::UnitX()) *
+  //               Eigen::AngleAxisf(original_rpy[1], Eigen::Vector3f::UnitY()) *
+  //               Eigen::AngleAxisf(state.yaw - std::get<0>(vel_angle_and_mag), Eigen::Vector3f::UnitZ());
+  //
+  //  pobj.predicted_position.orientation.x = final_quat.x();
+  //  pobj.predicted_position.orientation.y = final_quat.y();
+  //  pobj.predicted_position.orientation.z = final_quat.z();
+  //  pobj.predicted_position.orientation.w = final_quat.w();
+  //  Replace with logic above if this issue is decided: // https://github.com/usdot-fhwa-stol/carma-platform/issues/2401
 
   // Map twist
   // Constant velocity model means twist remains unchanged

--- a/motion_predict/src/predict_ctrv.cpp
+++ b/motion_predict/src/predict_ctrv.cpp
@@ -52,7 +52,7 @@ std::tuple<double, double> localVelOrientationAndMagnitude(const double v_x, con
 
 CTRV_State buildCTRVState(const geometry_msgs::msg::Pose& pose, const geometry_msgs::msg::Twist& twist)
 {
-  // TODO: Need a logic here to possible detect whether if twist.linear.x,y
+  // Need a logic here to possible detect whether if twist.linear.x,y
   // is in map frame. https://github.com/usdot-fhwa-stol/carma-platform/issues/2407
   auto vel_angle_and_mag = localVelOrientationAndMagnitude(twist.linear.x, twist.linear.y);
 

--- a/motion_predict/test/test_predict_ctrv.cpp
+++ b/motion_predict/test/test_predict_ctrv.cpp
@@ -47,7 +47,7 @@ TEST(predict_ctrv, buildCTRVState)
   CTRV_State result = buildCTRVState(pose, twist);
   ASSERT_NEAR(result.x, 1.3, 0.000001);
   ASSERT_NEAR(result.y, 1.4, 0.000001);
-  ASSERT_NEAR(result.yaw, 1.98902433, 0.00001);
+  ASSERT_NEAR(result.yaw, 0.41822, 0.00001); // directly uses direction of x, y
   ASSERT_NEAR(result.v, 4.9244289009, 0.000001);
   ASSERT_NEAR(result.yaw_rate, 0.0872665, 0.0000001);
 }
@@ -148,7 +148,8 @@ TEST(predict_ctrv, predictStepExternal)
   obj.pose.covariance[0] = 1;
   obj.pose.covariance[7] = 1;
   obj.pose.covariance[35] = 1;
-  obj.velocity.twist.linear.x = 4.9244289009; // Initial velocity speed
+  obj.velocity.twist.linear.x = 4.9244289009 * cos(yaw_angle); // Matching velocity to orientation, as currently map frame is expected in the velocity
+  obj.velocity.twist.linear.y = 4.9244289009 * sin(yaw_angle); // Matching velocity to orientation,  as currently map frame is expected in the velocity
   obj.velocity.covariance[0] = 999;
   obj.velocity.covariance[7] = 999;
   obj.velocity.covariance[35] = 999;
@@ -157,7 +158,8 @@ TEST(predict_ctrv, predictStepExternal)
 
   EXPECT_NEAR(5.3466, result.predicted_position.position.x, 0.00001);  // Verify x position update
   EXPECT_NEAR(1.7498, result.predicted_position.position.y, 0.00001);  // Verify y position update
-  EXPECT_NEAR(4.9244289009, result.predicted_velocity.linear.x, 0.00001); // Verify velocity speed
+  EXPECT_NEAR(4.9244289009 * cos(yaw_angle), result.predicted_velocity.linear.x, 0.00001); // Verify velocity speed
+  EXPECT_NEAR(4.9244289009 * sin(yaw_angle), result.predicted_velocity.linear.y, 0.00001); // Verify velocity speed
   EXPECT_NEAR(0.99, result.predicted_position_confidence, 0.01);
   EXPECT_NEAR(0.001, result.predicted_velocity_confidence, 0.001);
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR fixes the issue where predicted states of CTRV motion model is showing opposite direction (often flips back and forth). This is seriously impacting yielding behavior of carma due to bad prediction. 
So I put an example scenario where heavy vehicle is red, carma is green (you can see the camera view on right) and predicted states are showing as transforms. 
Truck is actually travelling lower left corner of the intersection as you can see from the truck's front being shown in the camera, but it is predicted backwards.

Before:
Because velocity is already in the map frame, if we add that angle to orientation like the old code, it will flip the direction to the opposite:
![image](https://github.com/usdot-fhwa-stol/carma-utils/assets/20613282/3bbe2fa2-5ed4-4d22-a9e9-a96d3d28dd43)
This is because old code assumed velocity was in base_link frame (which often just non-zero x value without noise which is the direction of travel) and pose orientation was the mostly the main yaw in CTRV. However, in simulation, all objects reported and used in carma's world model are already in map frame velocity, so it was "double counting".


atan fix: 
previously the function was only getting the angle from y value and not accounting x, which means angle in 3rd quadrant will be in 4th erroneously:

![image](https://github.com/usdot-fhwa-stol/carma-utils/assets/20613282/827b8229-cb70-4233-aa86-ad25a6dc1bfc)

after atan and frame fix:

![image](https://github.com/usdot-fhwa-stol/carma-utils/assets/20613282/04c96e9e-f5d7-4a3f-b24e-901492b08550)

I think technically the original code is correct, however, without this fix the current logic will not work. 
I have documented why we needed this "workaround" at the moment in the code and in here:
https://github.com/usdot-fhwa-stol/carma-platform/issues/2401

## Related GitHub Issue
fixes: https://github.com/usdot-fhwa-stol/carma-platform/issues/2398
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
https://usdot-carma.atlassian.net/browse/CAR-6058
<!-- e.g. CAR-123 -->

## Motivation and Context
During HASS and VOICE demo, it was discovered that vehicles's prediction would flip back and forith going opposite direction
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
sim pc 2, made scenario-runner heavy vehicle to travel lower left of the intersection and observed the prediction.
And also tested successfully on VOICES with simulated carma detecting real life carma's trajectory correctly using CTRV
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
