### PR TITLE
Add human-readable lifecycle transition logs

### DIFF
--- a/ros2_lifecycle_manager/include/ros2_lifecycle_manager/ros2_lifecycle_utils.hpp
+++ b/ros2_lifecycle_manager/include/ros2_lifecycle_manager/ros2_lifecycle_utils.hpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2024 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#ifndef ROS2_LIFECYCLE_MANAGER__ROS2_LIFECYCLE_UTILS_HPP_
+#define ROS2_LIFECYCLE_MANAGER__ROS2_LIFECYCLE_UTILS_HPP_
+
+#include <unordered_map>
+#include <string>
+#include "rclcpp/rclcpp.hpp"
+#include "lifecycle_msgs/msg/transition.hpp"
+
+namespace ros2_lifecycle_manager
+{
+// Define a map for transition IDs to human-readable names
+std::unordered_map<uint8_t, std::string> transition_map = {
+    {lifecycle_msgs::msg::Transition::TRANSITION_CREATE, "TRANSITION_CREATE"},
+    {lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE, "TRANSITION_CONFIGURE"},
+    {lifecycle_msgs::msg::Transition::TRANSITION_CLEANUP, "TRANSITION_CLEANUP"},
+    {lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE, "TRANSITION_ACTIVATE"},
+    {lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE, "TRANSITION_DEACTIVATE"},
+    {lifecycle_msgs::msg::Transition::TRANSITION_UNCONFIGURED_SHUTDOWN, "TRANSITION_UNCONFIGURED_SHUTDOWN"},
+    {lifecycle_msgs::msg::Transition::TRANSITION_INACTIVE_SHUTDOWN, "TRANSITION_INACTIVE_SHUTDOWN"},
+    {lifecycle_msgs::msg::Transition::TRANSITION_ACTIVE_SHUTDOWN, "TRANSITION_ACTIVE_SHUTDOWN"},
+    {lifecycle_msgs::msg::Transition::TRANSITION_DESTROY, "TRANSITION_DESTROY"},
+    {lifecycle_msgs::msg::Transition::TRANSITION_ON_CONFIGURE_SUCCESS, "TRANSITION_ON_CONFIGURE_SUCCESS"},
+    {lifecycle_msgs::msg::Transition::TRANSITION_ON_CONFIGURE_FAILURE, "TRANSITION_ON_CONFIGURE_FAILURE"},
+    {lifecycle_msgs::msg::Transition::TRANSITION_ON_CONFIGURE_ERROR, "TRANSITION_ON_CONFIGURE_ERROR"},
+    {lifecycle_msgs::msg::Transition::TRANSITION_ON_CLEANUP_SUCCESS, "TRANSITION_ON_CLEANUP_SUCCESS"},
+    {lifecycle_msgs::msg::Transition::TRANSITION_ON_CLEANUP_FAILURE, "TRANSITION_ON_CLEANUP_FAILURE"},
+    {lifecycle_msgs::msg::Transition::TRANSITION_ON_CLEANUP_ERROR, "TRANSITION_ON_CLEANUP_ERROR"},
+    {lifecycle_msgs::msg::Transition::TRANSITION_ON_ACTIVATE_SUCCESS, "TRANSITION_ON_ACTIVATE_SUCCESS"},
+    {lifecycle_msgs::msg::Transition::TRANSITION_ON_ACTIVATE_FAILURE, "TRANSITION_ON_ACTIVATE_FAILURE"},
+    {lifecycle_msgs::msg::Transition::TRANSITION_ON_ACTIVATE_ERROR, "TRANSITION_ON_ACTIVATE_ERROR"},
+    {lifecycle_msgs::msg::Transition::TRANSITION_ON_DEACTIVATE_SUCCESS, "TRANSITION_ON_DEACTIVATE_SUCCESS"},
+    {lifecycle_msgs::msg::Transition::TRANSITION_ON_DEACTIVATE_FAILURE, "TRANSITION_ON_DEACTIVATE_FAILURE"},
+    {lifecycle_msgs::msg::Transition::TRANSITION_ON_DEACTIVATE_ERROR, "TRANSITION_ON_DEACTIVATE_ERROR"},
+    {lifecycle_msgs::msg::Transition::TRANSITION_ON_SHUTDOWN_SUCCESS, "TRANSITION_ON_SHUTDOWN_SUCCESS"},
+    {lifecycle_msgs::msg::Transition::TRANSITION_ON_SHUTDOWN_FAILURE, "TRANSITION_ON_SHUTDOWN_FAILURE"},
+    {lifecycle_msgs::msg::Transition::TRANSITION_ON_SHUTDOWN_ERROR, "TRANSITION_ON_SHUTDOWN_ERROR"},
+    {lifecycle_msgs::msg::Transition::TRANSITION_ON_ERROR_SUCCESS, "TRANSITION_ON_ERROR_SUCCESS"},
+    {lifecycle_msgs::msg::Transition::TRANSITION_ON_ERROR_FAILURE, "TRANSITION_ON_ERROR_FAILURE"},
+    {lifecycle_msgs::msg::Transition::TRANSITION_ON_ERROR_ERROR, "TRANSITION_ON_ERROR_ERROR"},
+    {lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS, "TRANSITION_CALLBACK_SUCCESS"},
+    {lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_FAILURE, "TRANSITION_CALLBACK_FAILURE"},
+    {lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_ERROR, "TRANSITION_CALLBACK_ERROR"}
+};
+
+// Function to get human-readable name from transition ID
+std::string get_transition_name(uint8_t id)
+{
+    auto it = transition_map.find(id);
+    if (it != transition_map.end())
+    {
+        return it->second;
+    }
+    return "UNKNOWN_TRANSITION";
+}
+
+} // namespace ros2_lifecycle_manager
+
+#endif // ROS2_LIFECYCLE_MANAGER__ROS2_LIFECYCLE_UTILS_HPP_

--- a/ros2_lifecycle_manager/src/ros2_lifecycle_manager.cpp
+++ b/ros2_lifecycle_manager/src/ros2_lifecycle_manager.cpp
@@ -17,6 +17,8 @@
 #include <functional>
 #include <lifecycle_msgs/msg/state.hpp>
 #include "ros2_lifecycle_manager/ros2_lifecycle_manager.hpp"
+#include "ros2_lifecycle_manager/ros2_lifecycle_utils.hpp"
+
 
 namespace ros2_lifecycle_manager
 {
@@ -360,15 +362,23 @@ namespace ros2_lifecycle_manager
     // We have an answer, let's print our success.
     if (future.get().second->success)
     {
-      RCLCPP_INFO(
-          node_logging_->get_logger(), "Transition %d successfully triggered.", static_cast<int>(future.get().first->transition.id));
-      return true;
+        RCLCPP_INFO(
+            node_logging_->get_logger(),
+            "Transition %s (%d) successfully triggered.",
+            get_transition_name(future.get().first->transition.id).c_str(),
+            static_cast<int>(future.get().first->transition.id)
+        );
+        return true;
     }
     else
     {
-      RCLCPP_WARN(
-          node_logging_->get_logger(), "Failed to trigger transition %u", static_cast<unsigned int>(future.get().first->transition.id));
-      return false;
+        RCLCPP_WARN(
+            node_logging_->get_logger(),
+            "Failed to trigger transition %s (%u)",
+            get_transition_name(future.get().first->transition.id).c_str(),
+            static_cast<unsigned int>(future.get().first->transition.id)
+        );
+        return false;
     }
 
     return true;


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
During debugging or testing, lifecycle logs don't print human-readable transition ids. 
Due to this, users of carma-platform don't have context of what stage the carma-platform is unless they are intimately familiar with the ids. For example, transition.id 1 below is hard to understand:
```
platform_ros2                     | [guidance_controller-43] 1726033822.220037748 | INFO | guidance.guidance_controller | wait_on_change_state_future:363 | Transition 1 successfully triggered.
platform_ros2                     | [carma_component_container_mt-11] 1726033822.220110111 | WARN | LifecyclePublisher | publish:104 | Trying to publish message on the topic '/localization/localization_status', but the publisher is not activated
platform_ros2                     | [carma_component_container_mt-11] 1726033822.320015148 | WARN | LifecyclePublisher | publish:104 | Trying to publish message on the topic '/localization/localization_status', but the publisher is not activated
platform_ros2                     | [lifecycle_component_wrapper_mt-7] 1726033822.360261833 | INFO | environment.lanelet2_map_visualization | CarmaLifecycleNode:54 | CarmaLifecycleNode node launched, waiting on state transition requests
platform_ros2                     | [lifecycle_component_wrapper_mt-7] 1726033822.361215544 | INFO | environment.lanelet2_map_visualization_container | on_load_node:349 | A lifecycle component has been loaded by the LifecycleComponentWrapper. Attempting to move it to the ACTIVE state.

```

I added human-readable format so that it is easier for the users to understand what is happening:
```
                | [guidance_controller-43] 1726035780.013904770 | INFO | guidance.guidance_controller | wait_on_change_state_future:365 | Transition TRANSITION_CONFIGURE (1) successfully triggered.
platform_ros2                     | [guidance_controller-43] 1726035780.014598171 | INFO | guidance.guidance_controller | transition_multiplex:293 | Calling node: /guidance/route_node
platform_ros2                     | [guidance_controller-43] 1726035780.014787115 | INFO | guidance.guidance_controller | wait_on_change_state_future:350 | Waiting for future
platform_ros2                     | [carma_component_container_mt-22] 1726035780.026386140 | INFO | guidance.route_node | handle_on_configure:58 | Route trying to configure
platform_ros2                     | [carma_component_container_mt-22] 1726035780.027733745 | INFO | guidance.route_node | handle_on_configure:70 | Loaded params: route::Config { 
platform_ros2                     | [carma_component_container_mt-22] max_crosstrack_error: 2
platform_ros2                     | [carma_component_container_mt-22] destination_downtrack_range: 10
platform_ros2                     | [carma_component_container_mt-22] route_spin_rate: 10
platform_ros2                     | [carma_component_container_mt-22] cte_max_count: 4
platform_ros2                     | [carma_component_container_mt-22] route_file_path: /opt/carma/routes/
platform_ros2                     | [carma_component_container_mt-22] }
platform_ros2                     | [carma_component_container_mt-22] 
ros1_bridge                       | Failed to connect to 127.0.0.1:47945
ros1_bridge                       | Failed to connect to 127.0.0.1:47945
platform_ros2                     | [carma_component_container_mt-18] 1726035780.033258273
```


<!--- Describe your changes in detail -->

## Related GitHub Issue
NA. 
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
[CAR-6076](https://usdot-carma.atlassian.net/browse/CAR-6076)
<!-- e.g. CAR-123 -->

## Motivation and Context
As people other than carma-platform developers increasingly use the tool such as cdasim developers, it needs to be more user-friendly.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
local VM integration tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.


[CAR-6076]: https://usdot-carma.atlassian.net/browse/CAR-6076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ