### PR TITLE
Fix quintic polynomial equation solver

### DIFF
--- a/trajectory_utils_ros2/include/trajectory_utils/quintic_coefficient_calculator.hpp
+++ b/trajectory_utils_ros2/include/trajectory_utils/quintic_coefficient_calculator.hpp
@@ -23,8 +23,8 @@
 #include <Eigen/Dense>
 
 namespace quintic_coefficient_calculator {
-    
-    /*! 
+
+    /*!
     \brief  quintic_coefficient_calculator is used to solve quintic_coefficient for object avoidance .
     \param x0 position at time t0
     \param xt position at time t
@@ -36,6 +36,6 @@ namespace quintic_coefficient_calculator {
     \param tt goal time
     */
 
-    std::vector<double> quintic_coefficient_calculator(double x0, double xt, double v0, double vt, double a0, double at, __uint64_t t0, __uint64_t tt);
+    std::vector<double> quintic_coefficient_calculator(double x0, double xt, double v0, double vt, double a0, double at, double t0, double tt);
 
 }  // namespace quintic_coefficient_calculator

--- a/trajectory_utils_ros2/src/trajectory_utils/quintic_coefficient_calculator.cpp
+++ b/trajectory_utils_ros2/src/trajectory_utils/quintic_coefficient_calculator.cpp
@@ -23,27 +23,30 @@
 
 namespace quintic_coefficient_calculator {
 
-    std::vector<double> quintic_coefficient_calculator(double x0, double xt, double v0, double vt, double a0, double at, __uint64_t t0, __uint64_t tt ) {
+    std::vector<double> quintic_coefficient_calculator(double x0, double xt, double v0, double vt, double a0, double at, double t0, double tt) {
+        // Changed __uint64_t to double for time parameters to avoid potential conversion issues
 
         Eigen::VectorXd state_values(6);
         state_values << x0, xt, v0, vt, a0, at;
 
         Eigen::Matrix<double, 6, 6> mat;
 
+        // Position constraints at t0 and tt
         mat(0,0) = pow(t0, 5);
         mat(0,1) = pow(t0, 4);
-        mat(0,2) = pow(t0, 3); 
+        mat(0,2) = pow(t0, 3);
         mat(0,3) = pow(t0, 2);
         mat(0,4) = t0;
         mat(0,5) = 1;
 
         mat(1,0) = pow(tt, 5);
         mat(1,1) = pow(tt, 4);
-        mat(1,2) = pow(tt, 3); 
+        mat(1,2) = pow(tt, 3);
         mat(1,3) = pow(tt, 2);
         mat(1,4) = tt;
         mat(1,5) = 1;
 
+        // Velocity constraints at t0 and tt
         mat(2,0) = 5 * pow(t0, 4);
         mat(2,1) = 4 * pow(t0, 3);
         mat(2,2) = 3 * pow(t0, 2);
@@ -58,6 +61,7 @@ namespace quintic_coefficient_calculator {
         mat(3,4) = 1;
         mat(3,5) = 0;
 
+        // Acceleration constraints at t0 and tt
         mat(4,0) = 20 * pow(t0, 3);
         mat(4,1) = 12 * pow(t0, 2);
         mat(4,2) = 6 * t0;
@@ -72,10 +76,9 @@ namespace quintic_coefficient_calculator {
         mat(5,4) = 0;
         mat(5,5) = 0;
 
-        Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> mat_ = mat.inverse();
-        Eigen::VectorXd result;
-
-        result = mat_*state_values;
+        // Using direct solve instead of calculating the inverse explicitly
+        // This is both more numerically stable and more efficient
+        Eigen::VectorXd result = mat.colPivHouseholderQr().solve(state_values);
 
         std::vector<double> vector_result;
         for (size_t i = 0; i < result.size(); i++) {

--- a/trajectory_utils_ros2/src/trajectory_utils/quintic_coefficient_calculator.cpp
+++ b/trajectory_utils_ros2/src/trajectory_utils/quintic_coefficient_calculator.cpp
@@ -24,7 +24,6 @@
 namespace quintic_coefficient_calculator {
 
     std::vector<double> quintic_coefficient_calculator(double x0, double xt, double v0, double vt, double a0, double at, double t0, double tt) {
-        // Changed __uint64_t to double for time parameters to avoid potential conversion issues
 
         Eigen::VectorXd state_values(6);
         state_values << x0, xt, v0, vt, a0, at;


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
After we solve the equation, sometimes there was a slight deviation along the trajectory when we use back the equation to get speed and downtrack, and I was wondering why. Here is what I changed:

- Changed __uint64_t to double for time parameters to avoid losing precision as we use it with small double variables (remaining_time left to plan around 15.0 or so seconds).
- Uses a solver function instead of manually inverting and getting the answer. This method avoids dividing by zero. 
https://eigen.tuxfamily.org/dox/classEigen_1_1ColPivHouseholderQR.html#ad4825c3d43dffdf0c883de09ba891646
Seems more robust and I can actually see the if we use the coefficients the result is what we expect.

The original PR for this change is interestingly deleted or not accessible. So I am not sure why the uint64 was chosen except maybe it was trying to force positive number because it is a time.

## Related GitHub Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/2345
Will improve above but not necessarily fix all the way
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
NA
<!-- e.g. CAR-123 -->

## Motivation and Context
Improve Yield
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Sim PC
Resulting Coefficients actually result in matching output with online solver with given t (or x)
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
